### PR TITLE
GHA: add basic Gitleaks GitHub Action

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: gitleaks/gitleaks-action@v2
         env:


### PR DESCRIPTION
Add basic GitLeaks action to prevent/detect secrets leaks

https://gitleaks.io/products.html
https://github.com/marketplace/actions/gitleaks

Next step would be to have us install locally:

https://pre-commit.com/#install
https://github.com/gitleaks/gitleaks?tab=readme-ov-file#pre-commit