### PR TITLE
Helm: fix all references to oracle-pull now components-oracle

### DIFF
--- a/chains/solana/devnet-pull.yaml
+++ b/chains/solana/devnet-pull.yaml
@@ -24,8 +24,7 @@ components:
     push:
       queue: "uPeRMdfPmrPqgRWSrjAnAkH78RqAhe5kXoW6vBYRqFX"
       key: "<FILL_IN_HERE>"
-    pull:
+    oracle:
       queue: "5Qv744yu7DmEbU669GmYRqL9kpQsyYsaVKdR8YiBMTaP"
       host: "${SB_DNS}"
       key: "<FILL_IN_HERE>"
-

--- a/charts/pull-service/templates/gateway-deployment.yaml
+++ b/charts/pull-service/templates/gateway-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           value: {{ $values.heartbeatInterval | default "30" | quote }}
         -
           name: ORACLE_KEY
-          value: {{ $values.oracle.key | quote}}
+          value: {{ $values.components.key | quote}}
         -
           name: KEYPAIR_PATH
           value: "/data/protected_files/keypair.bin"
@@ -69,10 +69,10 @@ spec:
           value: "0"
         -
           name: GUARDIAN_INGRESS
-          value: "https://{{ $.Values.oracle.guardian.host }}"
+          value: "https://{{ $.Values.components.guardian.host }}"
         -
           name: ORACLE_INGRESS
-          value: "https://{{ $.Values.oracle.pull.host }}"
+          value: "https://{{ $.Values.components.oracle.host }}"
         -
           name: GATEWAY_INGRESS
           value: "https://{{ $.Values.gateway.host }}"
@@ -127,7 +127,7 @@ spec:
           value: {{ $values.quoteAddress | quote }}
         -
           name: ORACLE_AUTHORITY
-          value: {{ $values.oracle.authority }}
+          value: {{ $values.components.authority }}
 
         # METRICS
         -

--- a/charts/pull-service/templates/oracle-deployment.yaml
+++ b/charts/pull-service/templates/oracle-deployment.yaml
@@ -1,6 +1,6 @@
 {{- $values := .Values -}}
-{{- range $component, $config := .Values.oracle }}
-{{- if or (eq $component "guardian") (eq $component "push") (eq $component "pull") }}
+{{- range $component, $config := .Values.components }}
+{{- if or (eq $component "guardian") (eq $component "push") (eq $component "oracle") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: {{ $.Values.serviceAccount }}
       dnsPolicy: ClusterFirst
       containers:
-      - image: {{ $values.oracle.image }}
+      - image: {{ $values.components.image }}
         env:
         -
           name: CHAIN
@@ -78,28 +78,28 @@ spec:
           value: "1"
         -
           name: PULL_ORACLE
-          value: "{{ $.Values.oracle.pull.key }}"
+          value: "{{ $.Values.components.oracle.key }}"
         -
           name: PULL_QUEUE
-          value: "{{ $.Values.oracle.pull.queue }}"
+          value: "{{ $.Values.components.oracle.queue }}"
         -
           name: GUARDIAN_ORACLE
-          value: "{{ $.Values.oracle.guardian.key }}"
+          value: "{{ $.Values.components.guardian.key }}"
         -
           name: GUARDIAN_QUEUE
-          value: "{{ $.Values.oracle.guardian.queue }}"
+          value: "{{ $.Values.components.guardian.queue }}"
         -
           name: PUSH_ORACLE
-          value: "{{ $.Values.oracle.push.key }}"
+          value: "{{ $.Values.components.push.key }}"
         -
           name: PUSH_QUEUE
-          value: "{{ $.Values.oracle.push.queue }}"
+          value: "{{ $.Values.components.push.queue }}"
         -
           name: GUARDIAN_INGRESS
-          value: "https://{{ $.Values.oracle.guardian.host }}"
+          value: "https://{{ $.Values.components.guardian.host }}"
         -
           name: ORACLE_INGRESS
-          value: "https://{{ $.Values.oracle.pull.host }}"
+          value: "https://{{ $.Values.components.oracle.host }}"
         -
           name: GATEWAY_INGRESS
           value: "https://{{ $.Values.gateway.host }}"
@@ -136,7 +136,7 @@ spec:
         # SOLANA
         -
           name: ORACLE_AUTHORITY
-          value: {{ $values.oracle.authority }}
+          value: {{ $values.components.authority }}
 
         # METRICS
         -

--- a/charts/pull-service/templates/oracle-ingress.yaml
+++ b/charts/pull-service/templates/oracle-ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $component }}-oracle-ingress
+  name: {{ $component }}-ingress
   namespace: {{ $.Values.namespace }}
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt"
@@ -26,7 +26,7 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: {{ $component }}-oracle-service
+            name: {{ $component }}-service
             port:
               number: {{ $config.port }}
         pathType: ImplementationSpecific

--- a/charts/pull-service/templates/oracle-service.yaml
+++ b/charts/pull-service/templates/oracle-service.yaml
@@ -1,9 +1,9 @@
-{{- range $component, $config := .Values.oracle }}
-{{- if or (eq $component "guardian") (eq $component "push") (eq $component "pull") }}
+{{- range $component, $config := .Values.components }}
+{{- if or (eq $component "guardian") (eq $component "push") (eq $component "oracle") }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $component }}-oracle-service
+  name: {{ $component }}-service
   namespace: {{ $.Values.namespace }}
 spec:
   selector:
@@ -12,6 +12,7 @@ spec:
     - protocol: TCP
       port: {{ $config.port }}
       targetPort: {{ $config.port }}
+      name: {{ $component }}-svc
 ---
-{{- end }}          
-{{- end }}                
+{{- end }}
+{{- end }}

--- a/charts/pull-service/values.yaml
+++ b/charts/pull-service/values.yaml
@@ -42,11 +42,11 @@ ipfsUrl: "https://ipfs.infura.io:5001"
 attestationProgramId: ""
 gateway:
     host: "pull-gateway.switchboard.xyz"
-    image: "docker.io/switchboardlabs/pull-oracle:latest"
+    image: "docker.io/switchboardlabs/gateway:latest"
     port: 8082
 
 components:
-    image: "docker.io/switchboardlabs/gateway:latest"
+    image: "docker.io/switchboardlabs/pull-oracle:latest"
     key: ""
     queue: ""
     type: "oracle"
@@ -58,6 +58,8 @@ components:
     push:
       queue: ""
       key: ""
+      host: ""
+      port: 8089
     oracle:
       queue: ""
       key: ""


### PR DESCRIPTION
Fix all references to `oracle-pull` that is now `components/oracle` + cleaning

There were a few more refernces to the old nomenclature which needed to be
cleaned before the whole Chart would deploy cleanly.

Also had to force-upgrade since Helm was getting confused by the upgrade process.
