### PR TITLE
Fix Container names in Docker Compose

### DIFF
--- a/.scripts/docker-compose/common/webserver.yml
+++ b/.scripts/docker-compose/common/webserver.yml
@@ -2,6 +2,7 @@ services:
   # BEGIN SHARED MAIN WEBSERVER
   webserver:
     image: caddy
+    container_name: switchboard-webserver
     ports:
       # HTTP
       - target: 80

--- a/.scripts/docker-compose/devnet/docker-compose.yml
+++ b/.scripts/docker-compose/devnet/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       file: ../common/oracle.yml
       service: oracle
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:devnet}
+    container_name: devnet-oracle
     volumes:
       - ../../../data/devnet_protected_files/:/data/protected_files/
     networks:
@@ -37,6 +38,7 @@ services:
       file: ../common/guardian.yml
       service: guardian
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:devnet}
+    container_name: devnet-guardian
     volumes:
       - ../../../data/devnet_protected_files/:/data/protected_files/
     networks:
@@ -57,6 +59,7 @@ services:
       file: ../common/gateway.yml
       service: gateway
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:devnet}
+    container_name: devnet-gateway
     volumes:
       - ../../../data/devnet_protected_files/:/data/protected_files/
     networks:
@@ -76,6 +79,7 @@ services:
     extends:
       file: ../common/vmagent.yml
       service: vmagent
+    container_name: devnet-vmagent
     networks:
       - devnet
     volumes:

--- a/.scripts/docker-compose/mainnet/docker-compose.yml
+++ b/.scripts/docker-compose/mainnet/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       file: ../common/oracle.yml
       service: oracle
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:stable}
+    container_name: mainnet-oracle
     volumes:
       - ../../../data/mainnet_protected_files/:/data/protected_files/
     networks:
@@ -37,6 +38,7 @@ services:
       file: ../common/guardian.yml
       service: guardian
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:stable}
+    container_name: mainnet-guardian
     volumes:
       - ../../../data/mainnet_protected_files/:/data/protected_files/
     networks:
@@ -57,6 +59,7 @@ services:
       file: ../common/gateway.yml
       service: gateway
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:stable}
+    container_name: mainnet-gateway
     volumes:
       - ../../../data/mainnet_protected_files/:/data/protected_files/
     networks:
@@ -76,6 +79,7 @@ services:
     extends:
       file: ../common/vmagent.yml
       service: vmagent
+    container_name: mainnet-vmagent
     networks:
       - mainnet
     volumes:

--- a/.scripts/docker-compose/v2/docker-compose.yml
+++ b/.scripts/docker-compose/v2/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   v2-oracle:
     # dev-RC_06_30_24_23_12
     image: ${DOCKER_IMAGE:-docker.io/switchboardlabs/pull-oracle:v2-on-v3}
+    container_name: v2-oracle
     volumes:
       - ../../../data/deprecated_v2_protected_files/:/data/protected_files/
     networks:
@@ -55,6 +56,7 @@ services:
     extends:
       file: ../common/vmagent.yml
       service: vmagent
+    container_name: v2-vmagent
     networks:
       - v2
     volumes:


### PR DESCRIPTION
Simplified Docker Compose container names to avoid suffix numbers (-1, -2) as
we're meant to only run one set (devnet, mainnet, v2) of containers per host.
