### PR TITLE
Update sb-utils docker images

### DIFF
--- a/.scripts/sb/oracle-ctr-sb.sh
+++ b/.scripts/sb/oracle-ctr-sb.sh
@@ -16,7 +16,7 @@ sleep 3
 set -e
 
 export use_ctr="${1:-''}"
-export image="docker.io/switchboardlabs/sb-utils:3.5.8"
+export image="docker.io/switchboardlabs/sb-utils:3.5.9"
 
 if [[ "${use_ctr}" == "--ctr" ]]; then
 	set +e

--- a/.scripts/solana/oracle-ctr-sol.sh
+++ b/.scripts/solana/oracle-ctr-sol.sh
@@ -14,7 +14,7 @@ pkill -15 "${CTR_NAME}"
 set -e
 
 export use_ctr="${1:-''}"
-export image="docker.io/switchboardlabs/sb-utils:3.5.8"
+export image="docker.io/switchboardlabs/sb-utils:3.5.9"
 
 if [[ "${use_ctr}" == "--ctr" ]]; then
 	ctr i pull "${image}"


### PR DESCRIPTION
Update references to sb-utils docker image to the latest version.

Tested with latest 3.5.9 docker image and it works as expected:
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/73a21d2c-5618-4ba0-ba91-d2afd6600155">

<img width="861" alt="image" src="https://github.com/user-attachments/assets/94f78c77-e3f5-4df6-a991-c7939281c668">
