### PR TITLE
Add better oracle metrics collection

### DIFF
--- a/.scripts/helm/charts/sb-monitoring/Chart.lock
+++ b/.scripts/helm/charts/sb-monitoring/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: victoria-metrics-agent
+  repository: https://victoriametrics.github.io/helm-charts/
+  version: 0.15.8
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 5.30.0
+digest: sha256:ec10f513acd8d9448367221b3e5bd8cf2c90f343935ba71b7054c4f9a3ca5e98
+generated: "2025-02-15T01:09:34.502348-05:00"

--- a/.scripts/helm/charts/sb-monitoring/Chart.yaml
+++ b/.scripts/helm/charts/sb-monitoring/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: switchboard-monitoring
+description: A Helm chart for the Switchboard monitoring stack
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"
+
+dependencies:
+- name: victoria-metrics-agent
+  version: "0.15.8"
+  repository: "https://victoriametrics.github.io/helm-charts/"
+- name: kube-state-metrics
+  version: "5.30.0"
+  repository: "https://prometheus-community.github.io/helm-charts"
+
+icon: "https://raw.githubusercontent.com/switchboard-xyz/switchboard/main/website/static/img/icons/switchboard/avatar.png"

--- a/.scripts/helm/charts/sb-monitoring/values.yaml
+++ b/.scripts/helm/charts/sb-monitoring/values.yaml
@@ -1,0 +1,255 @@
+victoria-metrics-agent:
+  remoteWrite:
+    - url: "https://remote-write.switchboard.xyz/api/v1/write"
+
+  envFrom:
+    - configMapRef:
+        name: vmagent-env
+
+  config:
+    global:
+      scrape_interval: 30s
+      # The labels to add to any time series or alerts
+      external_labels:
+        operator: "%{CLUSTER_DOMAIN}"
+    scrape_configs: # 
+        - job_name: vmagent
+          static_configs:
+            - targets:
+                - localhost:8429
+        ## COPY from Prometheus helm chart https://github.com/helm/charts/blob/master/stable/prometheus/values.yaml
+        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          job_name: kubernetes-nodes
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - replacement: kubernetes.default.svc:443
+              target_label: __address__
+            - regex: (.+)
+              replacement: /api/v1/nodes/$1/proxy/metrics
+              source_labels:
+                - __meta_kubernetes_node_name
+              target_label: __metrics_path__
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true
+        - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          honor_timestamps: false
+          job_name: kubernetes-nodes-cadvisor
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - replacement: kubernetes.default.svc:443
+              target_label: __address__
+            - regex: (.+)
+              replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+              source_labels:
+                - __meta_kubernetes_node_name
+              target_label: __metrics_path__
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true
+        - job_name: kubernetes-service-endpoints
+          kubernetes_sd_configs:
+            - role: endpointslices
+          relabel_configs:
+            - action: drop
+              regex: true
+              source_labels:
+                - __meta_kubernetes_pod_container_init
+            - action: keep_if_equal
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_container_port_number
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container
+            - source_labels:
+                - __meta_kubernetes_namespace
+              target_label: namespace
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: service
+            - replacement: ${1}
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: node
+        - job_name: kubernetes-service-endpoints-slow
+          kubernetes_sd_configs:
+            - role: endpointslices
+          relabel_configs:
+            - action: drop
+              regex: true
+              source_labels:
+                - __meta_kubernetes_pod_container_init
+            - action: keep_if_equal
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_container_port_number
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+            - action: replace
+              regex: (https?)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              target_label: __scheme__
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container
+            - source_labels:
+                - __meta_kubernetes_namespace
+              target_label: namespace
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: service
+            - replacement: ${1}
+              source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: node
+          scrape_interval: 5m
+          scrape_timeout: 30s
+        - job_name: kubernetes-services
+          kubernetes_sd_configs:
+            - role: service
+          metrics_path: /probe
+          params:
+            module:
+                - http_2xx
+          relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_probe
+            - source_labels:
+                - __address__
+              target_label: __param_target
+            - replacement: blackbox
+              target_label: __address__
+            - source_labels:
+                - __param_target
+              target_label: instance
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_namespace
+              target_label: namespace
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: service
+        - job_name: kubernetes-pods
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - action: drop
+              regex: true
+              source_labels:
+                - __meta_kubernetes_pod_container_init
+            - action: keep_if_equal
+              source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+                - __meta_kubernetes_pod_container_port_number
+            - action: keep
+              regex: true
+              source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+                - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+                - __address__
+                - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - source_labels:
+                - __meta_kubernetes_pod_container_name
+              target_label: container
+            - source_labels:
+                - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: replace
+              source_labels:
+                - __meta_kubernetes_pod_node_name
+              target_label: node
+        - job_name: kube-state-metrics
+          kubernetes_sd_configs:
+          - role: pod
+          relabel_configs:
+
+            # Leave only targets with `kube-state-metrics` container name.
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            regex: kube-state-metrics
+            action: keep
+
+            # kube-state-metrics container may expose multiple ports.
+            # We need to scrape only the service port.
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            regex: "8080"
+            action: keep

--- a/.scripts/helm/charts/sb-monitoring/values.yaml
+++ b/.scripts/helm/charts/sb-monitoring/values.yaml
@@ -2,10 +2,6 @@ victoria-metrics-agent:
   remoteWrite:
     - url: "https://remote-write.switchboard.xyz/api/v1/write"
 
-  envFrom:
-    - configMapRef:
-        name: vmagent-env
-
   config:
     global:
       scrape_interval: 30s

--- a/.scripts/kubernetes/k8s-apps-vmagent.sh
+++ b/.scripts/kubernetes/k8s-apps-vmagent.sh
@@ -74,6 +74,7 @@ helm_values_file="${helm_chart_dir}/values.yaml"
 set +u
 
 echo "HELM: Installing switchboard-monitoring under namespace sb-monitoring"
+helm dependency build ${helm_chart_dir}
 helm upgrade -i "sb-monitoring" \
   -n "sb-monitoring" --create-namespace \
   -f "${helm_values_file}" \

--- a/.scripts/kubernetes/k8s-apps-vmagent.sh
+++ b/.scripts/kubernetes/k8s-apps-vmagent.sh
@@ -65,3 +65,19 @@ helm upgrade -i "vmagent-${cluster}" \
   -f "../../../.scripts/kubernetes/vmagent.yaml" \
   vm/victoria-metrics-agent >/dev/null
 echo "HELM: VictoriaMetrics Agent installed"
+
+repo_dir="$(readlink -f ../../..)"
+helm_dir="${repo_dir}/.scripts/helm/"
+helm_chart_dir="${helm_dir}/charts/sb-monitoring/"
+helm_values_file="${helm_chart_dir}/values.yaml"
+
+set +u
+
+echo "HELM: Installing switchboard-monitoring under namespace sb-monitoring"
+helm upgrade -i "sb-monitoring" \
+  -n "sb-monitoring" --create-namespace \
+  -f "${helm_values_file}" \
+  --set victoria-metrics-agent.config.global.external_labels.operator="${CLUSTER_DOMAIN}" \
+  "${helm_chart_dir}" >/dev/null
+echo "HELM: Installed sb-monitoring under namespace sb-monitoring"
+set -u

--- a/.scripts/kubernetes/k8s-apps-vmagent.sh
+++ b/.scripts/kubernetes/k8s-apps-vmagent.sh
@@ -72,9 +72,13 @@ helm_chart_dir="${helm_dir}/charts/sb-monitoring/"
 helm_values_file="${helm_chart_dir}/values.yaml"
 
 set +u
+echo "HELM: Adding prometheus-community repo"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+helm repo update >/dev/null
+echo "HELM: prometheus-community repo added"
 
 echo "HELM: Installing switchboard-monitoring under namespace sb-monitoring"
-helm dependency build ${helm_chart_dir}
+helm dependency build ${helm_chart_dir} >/dev/null
 helm upgrade -i "sb-monitoring" \
   -n "sb-monitoring" --create-namespace \
   -f "${helm_values_file}" \


### PR DESCRIPTION
### Summary
This PR adds adds a new vmagent to be installed with oracles that collects the following metrics:
- Memory and CPU usage of pods in the cluster
- kube-state-metrics (e.g. # of ready replicas in a deployment, container last terminated reason, container pending reason, other helpful metrics)
- a few other default cluster metrics that come with the vanilla victoria-metrics scrape config

### Testing
Ran `./73-k8s-apps-vmagent.sh` with my changes on a devnet oracle:
```bash
root@ovh-rbx-01:~/infra-external/oracle/bare-metal/kubernetes# ./73-k8s-apps-vmagent.sh
HELM: adding VictoriaMetrics repo
HELM: VictoriaMetrics repo added
KUBECTL: creating ConfigMap switchboard-oracle-devnet/vmagent-env (remove and recreate if exists)
KUBECTL: creation completed
HELM: installing VictoriaMetrics Agent in your cluster
HELM: VictoriaMetrics Agent installed
HELM: Adding prometheus-community repo
HELM: prometheus-community repo added
HELM: Installing switchboard-monitoring under namespace sb-monitoring
HELM: Installed sb-monitoring under namespace sb-monitoring
root@ovh-rbx-01:~/infra-external/oracle/bare-metal/kubernetes#
```

⚠️ For some reason the metrics being reported by cadvisor (which is what vmagent is scraping) for the confidential containers is different from what the k8s metrics-server is reporting:
- cadvisor is saying the oracle pod is using ~1GiB memory: https://grafana.switchboard.xyz/goto/FwYTMIcNR?orgId=1
- `k top po` is claiming ~60 MiB <img width="907" alt="image" src="https://github.com/user-attachments/assets/20fff033-1da7-4bef-be2c-7ca62040d623" />
- if you compare the resource usage of the vmagent to the oracle/guardian/gateway the ratios are way off

It might be related to https://github.com/kata-containers/runtime/issues/2377
But I'm not sure if `k top pods` is wrong or the metrics being scraped.