### PR TITLE
Move runtime credentials to Kubernetes Secrets

### DIFF
--- a/.scripts/helm/cfg/devnet-solana-values.yaml
+++ b/.scripts/helm/cfg/devnet-solana-values.yaml
@@ -30,4 +30,6 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
 
-jupiterSwapApiKey: "3a3b41bc06d49f9c89a8550ff84072be"
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"

--- a/.scripts/helm/cfg/mainnet-solana-values.yaml
+++ b/.scripts/helm/cfg/mainnet-solana-values.yaml
@@ -30,4 +30,6 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
 
-jupiterSwapApiKey: "3a3b41bc06d49f9c89a8550ff84072be"
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"

--- a/.scripts/helm/charts/on-demand/templates/gateway.yaml
+++ b/.scripts/helm/charts/on-demand/templates/gateway.yaml
@@ -100,18 +100,15 @@ spec:
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.gateway.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/templates/guardian.yaml
+++ b/.scripts/helm/charts/on-demand/templates/guardian.yaml
@@ -100,18 +100,15 @@ spec:
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret | quote }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.guardian.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/templates/oracle.yaml
+++ b/.scripts/helm/charts/on-demand/templates/oracle.yaml
@@ -102,18 +102,15 @@ spec:
         - name: KEYPAIR_PATH
           value: "/data/protected_files/keypair.bin"
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.oracle.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/tests/credential-secret-refs.sh
+++ b/.scripts/helm/charts/on-demand/tests/credential-secret-refs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+
+helm lint "${chart_dir}"
+helm template credential-test "${chart_dir}" >"${rendered}"
+
+for component in oracle guardian gateway; do
+  rg -q "name: ${component}" "${rendered}"
+done
+if rg -U -q 'name: (JUPITER_SWAP_API_KEY|PAYER_SECRET)\n[[:space:]]+value:' "${rendered}"; then
+  printf "a credential environment variable rendered as plaintext\n" >&2
+  exit 1
+fi
+if rg -n '^jupiterSwapApiKey:' "${chart_dir}" "$(dirname "${chart_dir}")/../cfg"; then
+  printf "a plaintext Jupiter credential field remains in Helm source\n" >&2
+  exit 1
+fi
+[[ "$(rg -c 'name: "jupiter-swap-api"' "${rendered}")" -eq 3 ]] || {
+  printf "not every workload references the Jupiter Kubernetes Secret\n" >&2
+  exit 1
+}
+[[ "$(rg -c 'name: payer-secret' "${rendered}")" -eq 3 ]] || {
+  printf "not every workload references the payer Kubernetes Secret\n" >&2
+  exit 1
+}
+
+printf "credential Secret reference assertions passed\n"

--- a/.scripts/helm/charts/on-demand/values.yaml
+++ b/.scripts/helm/charts/on-demand/values.yaml
@@ -9,14 +9,15 @@ computeUnitPrice: 1
 
 heartbeatInterval: 180
 
-payerSecret: ""
-payerSecretKey: ""
+payerSecretKey: "SOLANA_KEY"
 
 rpcUrl: ""
 wssRpcUrl: ""
 solanaMainnetRpc: ""
 
-jupiterSwapApiKey: ""
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"
 
 debug: ""
 verbose: ""
@@ -100,4 +101,3 @@ components:
       requests:
         cpu: "100m"
         memory: "100Mi"
-

--- a/.scripts/kubernetes/k8s-oracle-install.sh
+++ b/.scripts/kubernetes/k8s-oracle-install.sh
@@ -16,6 +16,8 @@ if [[ "${cluster}" != "devnet" &&
 fi
 
 export GUARDIAN_ENABLED="true"
+export JUPITER_SWAP_API_KEY_SECRET_NAME="${JUPITER_SWAP_API_KEY_SECRET_NAME:-jupiter-swap-api}"
+export JUPITER_SWAP_API_KEY_SECRET_KEY="${JUPITER_SWAP_API_KEY_SECRET_KEY:-api-key}"
 
 # defaults - these variables can be changed via `cfg/` files
 export DEVNET_DOCKER_IMAGE_TAG="devnet"
@@ -45,6 +47,47 @@ if [[ "$(kubectl get ns | grep -e '^'${NAMESPACE}'\W')" == "" ]]; then
   kubectl create namespace "${NAMESPACE}"
   printf "KUBECTL: Namespace ${NAMESPACE} created\n"
 fi
+
+if [[ "${PAYER_SECRET_KEY}" != "" ]]; then
+  payer_file="${repo_dir}/data/${cluster}_payer.json"
+  [[ -r "${payer_file}" ]] || {
+    printf "payer key file is missing or unreadable\n" >&2
+    exit 1
+  }
+  kubectl -n "${NAMESPACE}" create secret generic payer-secret \
+    --from-file="${PAYER_SECRET_KEY}=${payer_file}" \
+    --dry-run=client -o yaml |
+    kubectl apply -f -
+  kubectl -n "${NAMESPACE}" get secret payer-secret \
+    -o "jsonpath={.data.${PAYER_SECRET_KEY}}" |
+    grep -q . || {
+    printf "payer-secret does not contain the configured key\n" >&2
+    exit 1
+  }
+fi
+
+if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
+  [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] || {
+    printf "JUPITER_SWAP_API_KEY_FILE is unreadable\n" >&2
+    exit 1
+  }
+  kubectl -n "${NAMESPACE}" create secret generic \
+    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+    --from-file="${JUPITER_SWAP_API_KEY_SECRET_KEY}=${JUPITER_SWAP_API_KEY_FILE}" \
+    --dry-run=client -o yaml |
+    kubectl apply -f -
+elif ! kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  >/dev/null 2>&1; then
+  printf "%s is missing; set JUPITER_SWAP_API_KEY_FILE to provision the replacement credential\n" \
+    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" >&2
+  exit 1
+fi
+kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" |
+  grep -q . || {
+  printf "Jupiter API Secret does not contain the configured key\n" >&2
+  exit 1
+}
 
 helm_dir="${repo_dir}/.scripts/helm/"
 helm_charts_dir="${helm_dir}/charts/"
@@ -80,26 +123,10 @@ helm upgrade -i "sb-oracle-${NETWORK}" \
   --set components.guardian.image="${GUARDIAN_DOCKER_IMAGE}" \
   --set components.gateway.enabled=${GATEWAY_ENABLED} \
   --set components.gateway.image="${GATEWAY_DOCKER_IMAGE}" \
+  --set-string jupiterSwapApiKeySecret.name="${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  --set-string jupiterSwapApiKeySecret.key="${JUPITER_SWAP_API_KEY_SECRET_KEY}" \
   "${helm_on_demand_chart_dir}" >/dev/null
 printf "HELM: Switchboard Oracle installed under namespace ${NAMESPACE}\n"
-
-if [[ "${PAYER_SECRET_KEY}" != "" ]]; then
-  printf "KUBECTL: creating secret ${NAMESPACE}/payer-secret\n"
-  # delete pre-existing secret
-  set +e
-  kubectl \
-    -n "${NAMESPACE}" \
-    delete secret payer-secret >/dev/null 2>&1
-  set -e
-
-  # re-create secret
-  kubectl \
-    -n "${NAMESPACE}" \
-    create secret generic \
-    --from-file="${PAYER_SECRET_KEY}=../../../data/${cluster}_payer.json" \
-    payer-secret >/dev/null
-  printf "KUBECTL: secret ${NAMESPACE}/payer-secret created\n"
-fi
 
 if [[ "${LANDING_ENABLED}" != "" && "${LANDING_ENABLED}" == "true" ]]; then
   printf "HELM: Installing Switchboard Landing page under namespace ${LANDING_NAMESPACE}\n"


### PR DESCRIPTION
## Summary

- remove runtime credentials from tracked Helm values
- load guardian, oracle, and gateway credentials through Kubernetes `secretKeyRef`
- make the installer verify required Secret names and keys before Helm runs
- add a render test that fails if plaintext credential values return

## Why

An active credential was present in repository configuration. This change removes the live value from repository HEAD and rendered manifests while keeping credential material in Kubernetes Secrets.

## Stack

1. **This PR:** credential and Secret-reference prerequisite
2. [switchboard-xyz/infra-external#71](https://github.com/switchboard-xyz/infra-external/pull/71): guardian rollout and remediation safeguards

Application release prerequisite: [switchboard-xyz/sbv3#1061](https://github.com/switchboard-xyz/sbv3/pull/1061).

Merge and deploy this prerequisite before the guardian resilience layer.

## Verification

- credential Secret-reference render test passed
- Helm rendering contains Secret references instead of plaintext values
- targeted repository scan found no credential value in the changed source
- `git diff --check` passed

GitHub's GitLeaks action currently fails before scanning this fork PR because the organization's `GITLEAKS_LICENSE` Secret is not exposed to fork workflows. An upstream maintainer branch or authorized maintainer rerun is required; the workflow should not be weakened to expose repository Secrets to fork code.

## Deployment boundary

Merging this PR does not rotate or revoke any credential. Before deploying it, provision the replacement Kubernetes Secrets on the exact authorized targets and verify their required keys. After every consumer has moved to the replacement, verify the service and revoke the exposed value.

Do not deploy this change to a host that does not already have its replacement Secret. Devnet and mainnet Secret mutations require separate authorization.
