### PR TITLE
Add guardian resilience and Kata self-healing

### DIFF
--- a/.scripts/helm/cfg/devnet-solana-values.yaml
+++ b/.scripts/helm/cfg/devnet-solana-values.yaml
@@ -29,6 +29,7 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
+heartbeatRpcFallbackUrls: "https://api.devnet.solana.com"
 
 jupiterSwapApiKeySecret:
   name: "jupiter-swap-api"

--- a/.scripts/helm/cfg/devnet-solana-values.yaml
+++ b/.scripts/helm/cfg/devnet-solana-values.yaml
@@ -30,4 +30,6 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
 
-jupiterSwapApiKey: "3a3b41bc06d49f9c89a8550ff84072be"
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"

--- a/.scripts/helm/cfg/mainnet-solana-values.yaml
+++ b/.scripts/helm/cfg/mainnet-solana-values.yaml
@@ -29,6 +29,7 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
+heartbeatRpcFallbackUrls: "https://api.mainnet-beta.solana.com"
 
 jupiterSwapApiKeySecret:
   name: "jupiter-swap-api"

--- a/.scripts/helm/cfg/mainnet-solana-values.yaml
+++ b/.scripts/helm/cfg/mainnet-solana-values.yaml
@@ -30,4 +30,6 @@ solanaMainnetRpc: "__TASK_RUNNER_SOLANA_RPC__"
 rpcUrl: "__RPC_URL__"
 wssRpcUrl: "__WSS_RPC_URL__"
 
-jupiterSwapApiKey: "3a3b41bc06d49f9c89a8550ff84072be"
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"

--- a/.scripts/helm/charts/on-demand/templates/gateway.yaml
+++ b/.scripts/helm/charts/on-demand/templates/gateway.yaml
@@ -100,18 +100,15 @@ spec:
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.gateway.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/templates/guardian-remediator.yaml
+++ b/.scripts/helm/charts/on-demand/templates/guardian-remediator.yaml
@@ -1,0 +1,96 @@
+{{- if and $.Values.components.guardian.enabled $.Values.components.guardian.remediator.enabled }}
+{{- $guardianDigest := required "guardian remediator requires components.guardian.imageDigest" $.Values.components.guardian.imageDigest -}}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $guardianDigest) -}}
+{{- fail "components.guardian.imageDigest must be a sha256 digest when the remediator is enabled" -}}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: guardian-remediator
+  namespace: {{ $.Values.namespace | quote }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: guardian-remediator
+  namespace: {{ $.Values.namespace | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["guardian"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: guardian-remediator
+  namespace: {{ $.Values.namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: guardian-remediator
+subjects:
+  - kind: ServiceAccount
+    name: guardian-remediator
+    namespace: {{ $.Values.namespace | quote }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: guardian-remediator
+  namespace: {{ $.Values.namespace | quote }}
+spec:
+  schedule: {{ $.Values.components.guardian.remediator.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ $.Values.components.guardian.remediator.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $.Values.components.guardian.remediator.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 50
+      template:
+        metadata:
+          labels:
+            app: guardian-remediator
+        spec:
+          serviceAccountName: guardian-remediator
+          automountServiceAccountToken: true
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: guardian-remediator
+              image: {{ printf "%s@%s" $.Values.components.guardian.image $guardianDigest | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/app/guardian-remediator"]
+              env:
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: GUARDIAN_DEPLOYMENT
+                  value: guardian
+                - name: RUST_LOG
+                  value: info
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                limits:
+                  cpu: {{ $.Values.components.guardian.remediator.resources.limits.cpu }}
+                  memory: {{ $.Values.components.guardian.remediator.resources.limits.memory }}
+                requests:
+                  cpu: {{ $.Values.components.guardian.remediator.resources.requests.cpu }}
+                  memory: {{ $.Values.components.guardian.remediator.resources.requests.memory }}
+{{- end }}

--- a/.scripts/helm/charts/on-demand/templates/guardian.yaml
+++ b/.scripts/helm/charts/on-demand/templates/guardian.yaml
@@ -100,18 +100,15 @@ spec:
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret | quote }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.guardian.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/templates/guardian.yaml
+++ b/.scripts/helm/charts/on-demand/templates/guardian.yaml
@@ -1,4 +1,11 @@
-{{ if $.Values.components.guardian.enabled }}
+{{- if $.Values.components.guardian.enabled }}
+{{- $guardianDigest := $.Values.components.guardian.imageDigest | default "" -}}
+{{- if and $guardianDigest (not (regexMatch "^sha256:[a-f0-9]{64}$" $guardianDigest)) -}}
+{{- fail "components.guardian.imageDigest must be empty or a sha256 digest" -}}
+{{- end -}}
+{{- if and $.Values.components.guardian.remediator.enabled (not $guardianDigest) -}}
+{{- fail "components.guardian.remediator.enabled requires components.guardian.imageDigest" -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 
@@ -8,15 +15,17 @@ metadata:
 
   labels:
     chain: {{ $.Values.chain | quote }}
-    cluster: {{ $.Values.cluter | quote }}
+    cluster: {{ $.Values.cluster | quote }}
     app: guardian
 
+  {{- if not $guardianDigest }}
   annotations:
     keel.sh/approvals: "0"
     keel.sh/trigger: "poll"                                 # enable active repository checking (webhooks and GCR would still work)
     keel.sh/match-tag: "true"                               # only makes a difference when used with 'force' policy, will only update if tag matches :dev->:dev, :prod->:prod
     keel.sh/policy: "force"
     #keel.sh/pollSchedule: "@every 1m"
+  {{- end }}
 
 spec:
   replicas: 1
@@ -26,9 +35,7 @@ spec:
       app: guardian
 
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    type: Recreate
 
   template:
     metadata:
@@ -45,7 +52,7 @@ spec:
       dnsPolicy: ClusterFirst # TODO: probably not needed.. to be removed
 
       containers:
-      - image: {{ printf "%s:%s" $.Values.components.guardian.image $.Values.components.docker_image_tag | quote }}
+      - image: {{ ternary (printf "%s@%s" $.Values.components.guardian.image $guardianDigest) (printf "%s:%s" $.Values.components.guardian.image $.Values.components.docker_image_tag) (ne $guardianDigest "") | quote }}
         imagePullPolicy: Always #IfNotPresent
         name: guardian
 
@@ -58,7 +65,7 @@ spec:
         - name: SEV_SNP_CACHE_PATH
           value: "/tmp/certs"
         - name: DOCKER_IMAGE_TAG
-          value: {{ $.Values.components.docker_image_tag | quote }}
+          value: {{ ternary $guardianDigest $.Values.components.docker_image_tag (ne $guardianDigest "") | quote }}
         - name: CHAIN
           value: {{ $.Values.chain | quote }}
         - name: CLUSTER
@@ -97,6 +104,8 @@ spec:
           value: {{ $.Values.rpcUrl | quote }}
         - name: WSS_RPC_URL
           value: {{ $.Values.wssRpcUrl | quote }}
+        - name: HEARTBEAT_RPC_FALLBACK_URLS
+          value: {{ $.Values.heartbeatRpcFallbackUrls | quote }}
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: PAYER_SECRET
@@ -109,6 +118,13 @@ spec:
             secretKeyRef:
               name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
               key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
+        {{- if $.Values.pagerDutySecret.name }}
+        - name: PAGERDUTY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pagerDutySecret.name | quote }}
+              key: {{ required "pagerDutySecret.key is required when pagerDutySecret.name is set" $.Values.pagerDutySecret.key | quote }}
+        {{- end }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.guardian.metrics.exporter | quote }}
@@ -150,15 +166,29 @@ spec:
           failureThreshold: 10
           periodSeconds: 10
           timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: {{ $.Values.components.guardian.metrics.port }}
+          initialDelaySeconds: 15
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
         {{ end }}
 
         resources:
           limits:
             cpu: {{ $.Values.components.guardian.resources.limits.cpu }}
             memory: {{ $.Values.components.guardian.resources.limits.memory }}
+            {{- if $.Values.components.guardian.ephemeralStorage.enabled }}
+            ephemeral-storage: {{ $.Values.components.guardian.ephemeralStorage.limit }}
+            {{- end }}
           requests:
             cpu: {{ $.Values.components.guardian.resources.requests.cpu }}
             memory: {{ $.Values.components.guardian.resources.requests.memory }}
+            {{- if $.Values.components.guardian.ephemeralStorage.enabled }}
+            ephemeral-storage: {{ $.Values.components.guardian.ephemeralStorage.request }}
+            {{- end }}
 
 ---
 apiVersion: v1

--- a/.scripts/helm/charts/on-demand/templates/oracle.yaml
+++ b/.scripts/helm/charts/on-demand/templates/oracle.yaml
@@ -102,18 +102,15 @@ spec:
         - name: KEYPAIR_PATH
           value: "/data/protected_files/keypair.bin"
         - name: PAYER_SECRET
-          {{ if or (ne $.Values.payerSecretKey "") }}
           valueFrom:
             secretKeyRef:
-              {{ if $.Values.payerSecretKey }}
               name: payer-secret
-              key: {{  $.Values.payerSecretKey | quote }}
-              {{ end }}
-          {{ else }}
-          value: {{ $.Values.payerSecret }}
-          {{ end }}
+              key: {{ required "payerSecretKey is required" $.Values.payerSecretKey | quote }}
         - name: JUPITER_SWAP_API_KEY
-          value: {{ $.Values.jupiterSwapApiKey | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "jupiterSwapApiKeySecret.name is required" $.Values.jupiterSwapApiKeySecret.name | quote }}
+              key: {{ required "jupiterSwapApiKeySecret.key is required" $.Values.jupiterSwapApiKeySecret.key | quote }}
         # METRICS
         - name: METRICS_EXPORTER
           value: {{ $.Values.components.oracle.metrics.exporter | quote }}

--- a/.scripts/helm/charts/on-demand/templates/oracle.yaml
+++ b/.scripts/helm/charts/on-demand/templates/oracle.yaml
@@ -97,6 +97,8 @@ spec:
           value: {{ $.Values.rpcUrl | quote }}
         - name: WSS_RPC_URL
           value: {{ $.Values.wssRpcUrl | quote }}
+        - name: HEARTBEAT_RPC_FALLBACK_URLS
+          value: {{ $.Values.heartbeatRpcFallbackUrls | quote }}
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
         - name: KEYPAIR_PATH

--- a/.scripts/helm/charts/on-demand/tests/credential-secret-refs.sh
+++ b/.scripts/helm/charts/on-demand/tests/credential-secret-refs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered="$(mktemp)"
+trap 'rm -f "${rendered}"' EXIT
+
+helm lint "${chart_dir}"
+helm template credential-test "${chart_dir}" >"${rendered}"
+
+for component in oracle guardian gateway; do
+  rg -q "name: ${component}" "${rendered}"
+done
+if rg -U -q 'name: (JUPITER_SWAP_API_KEY|PAYER_SECRET)\n[[:space:]]+value:' "${rendered}"; then
+  printf "a credential environment variable rendered as plaintext\n" >&2
+  exit 1
+fi
+if rg -n '^jupiterSwapApiKey:' "${chart_dir}" "$(dirname "${chart_dir}")/../cfg"; then
+  printf "a plaintext Jupiter credential field remains in Helm source\n" >&2
+  exit 1
+fi
+[[ "$(rg -c 'name: "jupiter-swap-api"' "${rendered}")" -eq 3 ]] || {
+  printf "not every workload references the Jupiter Kubernetes Secret\n" >&2
+  exit 1
+}
+[[ "$(rg -c 'name: payer-secret' "${rendered}")" -eq 3 ]] || {
+  printf "not every workload references the payer Kubernetes Secret\n" >&2
+  exit 1
+}
+
+printf "credential Secret reference assertions passed\n"

--- a/.scripts/helm/charts/on-demand/tests/guardian-resilience.sh
+++ b/.scripts/helm/charts/on-demand/tests/guardian-resilience.sh
@@ -64,6 +64,30 @@ if rg -q 'verbs:.*delete|PAYER_SECRET|RPC_URL|runtimeClassName' "${remediator_re
   exit 1
 fi
 
+install_script="$(dirname "${chart_dir}")/../../kubernetes/k8s-oracle-install.sh"
+fleet_script="$(dirname "${chart_dir}")/../../kubernetes/guardian-fleet-health.sh"
+rollout_script="$(dirname "${chart_dir}")/../../kubernetes/guardian-rollout-one.sh"
+rg -q 'verify_fleet_health_attestation' "${install_script}"
+rg -q 'validate_secret_inputs' "${install_script}"
+rg -q 'StrictHostKeyChecking=yes' "${fleet_script}" "${rollout_script}"
+rg -q 'k3s kubectl' "${fleet_script}"
+rg -F -q "go-template='{{len .items}}'" "${fleet_script}"
+rg -q 'GUARDIAN_FLEET_CLUSTER=.*cluster' "${rollout_script}"
+rg -q 'deployed_cluster.*expected_cluster' "${fleet_script}"
+rg -q 'heartbeat_interval.*expected_heartbeat_interval' "${fleet_script}"
+rg -q '\$1 == target && \$2 == expected_cluster' "${rollout_script}"
+if rg -q 'kubectl --context' "${fleet_script}"; then
+  printf "fleet health checker must use the bare-metal SSH/k3s access path\n" >&2
+  exit 1
+fi
+preflight_line="$(rg -n '^validate_secret_inputs$' "${install_script}" | cut -d: -f1)"
+lint_line="$(rg -n '^helm lint ' "${install_script}" | cut -d: -f1)"
+mutation_line="$(rg -n '^ensure_namespace$' "${install_script}" | cut -d: -f1)"
+if ((preflight_line >= mutation_line || lint_line >= mutation_line)); then
+  printf "installer mutates Kubernetes before completing read-only preflights\n" >&2
+  exit 1
+fi
+
 rg -q 'keel\.sh/trigger: "poll"' "${tag_render}"
 rg -q 'image: "docker.io/switchboardlabs/guardian:devnet"' "${tag_render}"
 if rg -q 'ephemeral-storage:' "${guardian_render}"; then

--- a/.scripts/helm/charts/on-demand/tests/guardian-resilience.sh
+++ b/.scripts/helm/charts/on-demand/tests/guardian-resilience.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -f "${tmp_dir}"/*.yaml; rmdir "${tmp_dir}"' EXIT
+
+digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+guardian_render="${tmp_dir}/guardian.yaml"
+remediator_render="${tmp_dir}/remediator.yaml"
+tag_render="${tmp_dir}/guardian-tag.yaml"
+storage_render="${tmp_dir}/guardian-storage.yaml"
+all_render="${tmp_dir}/all.yaml"
+
+helm lint "${chart_dir}" \
+  --set-string "components.guardian.imageDigest=${digest}" \
+  --set "components.guardian.remediator.enabled=true"
+
+helm template guardian-test "${chart_dir}" \
+  --show-only templates/guardian.yaml \
+  --set-string "components.guardian.imageDigest=${digest}" \
+  --set "components.guardian.remediator.enabled=true" \
+  --set-string "pagerDutySecret.name=guardian-pagerduty" \
+  >"${guardian_render}"
+helm template guardian-test "${chart_dir}" \
+  --show-only templates/guardian-remediator.yaml \
+  --set-string "components.guardian.imageDigest=${digest}" \
+  --set "components.guardian.remediator.enabled=true" \
+  >"${remediator_render}"
+helm template guardian-test "${chart_dir}" \
+  --show-only templates/guardian.yaml \
+  --set "components.guardian.remediator.enabled=false" \
+  >"${tag_render}"
+helm template guardian-test "${chart_dir}" \
+  --show-only templates/guardian.yaml \
+  --set-string "components.guardian.imageDigest=${digest}" \
+  --set "components.guardian.ephemeralStorage.enabled=true" \
+  >"${storage_render}"
+helm template guardian-test "${chart_dir}" \
+  --set-string "components.guardian.imageDigest=${digest}" \
+  --set "components.guardian.remediator.enabled=true" \
+  >"${all_render}"
+
+rg -q 'type: Recreate' "${guardian_render}"
+rg -q "image: \"docker.io/switchboardlabs/guardian@${digest}\"" "${guardian_render}"
+rg -q 'path: /ready' "${guardian_render}"
+rg -q 'name: HEARTBEAT_RPC_FALLBACK_URLS' "${guardian_render}"
+rg -q 'name: "jupiter-swap-api"' "${guardian_render}"
+rg -q 'name: payer-secret' "${guardian_render}"
+rg -q 'name: PAGERDUTY_API_KEY' "${guardian_render}"
+rg -q 'name: "guardian-pagerduty"' "${guardian_render}"
+if rg -q 'keel\.sh/' "${guardian_render}"; then
+  printf "digest-pinned guardian unexpectedly contains Keel annotations\n" >&2
+  exit 1
+fi
+
+rg -q 'resourceNames: \["guardian"\]' "${remediator_render}"
+rg -q 'verbs: \["get", "patch"\]' "${remediator_render}"
+rg -q 'concurrencyPolicy: Forbid' "${remediator_render}"
+rg -q 'readOnlyRootFilesystem: true' "${remediator_render}"
+rg -q 'runAsNonRoot: true' "${remediator_render}"
+if rg -q 'verbs:.*delete|PAYER_SECRET|RPC_URL|runtimeClassName' "${remediator_render}"; then
+  printf "remediator manifest contains forbidden authority or guardian configuration\n" >&2
+  exit 1
+fi
+
+rg -q 'keel\.sh/trigger: "poll"' "${tag_render}"
+rg -q 'image: "docker.io/switchboardlabs/guardian:devnet"' "${tag_render}"
+if rg -q 'ephemeral-storage:' "${guardian_render}"; then
+  printf "ephemeral-storage rendered before Kata accounting was explicitly enabled\n" >&2
+  exit 1
+fi
+rg -q 'ephemeral-storage: 8Gi' "${storage_render}"
+rg -q 'ephemeral-storage: 1Gi' "${storage_render}"
+
+if helm template guardian-test "${chart_dir}" \
+  --set "components.guardian.remediator.enabled=true" >/dev/null 2>&1; then
+  printf "remediator rendered without an immutable image digest\n" >&2
+  exit 1
+fi
+
+if rg -n '^jupiterSwapApiKey:' "${chart_dir}" "$(dirname "${chart_dir}")/../cfg"; then
+  printf "plaintext Jupiter API key value remains in Helm source\n" >&2
+  exit 1
+fi
+if rg -U -q 'name: (JUPITER_SWAP_API_KEY|PAYER_SECRET)\n[[:space:]]+value:' "${all_render}"; then
+  printf "a credential environment variable rendered as plaintext\n" >&2
+  exit 1
+fi
+
+printf "guardian Helm resilience assertions passed\n"

--- a/.scripts/helm/charts/on-demand/values.yaml
+++ b/.scripts/helm/charts/on-demand/values.yaml
@@ -9,14 +9,15 @@ computeUnitPrice: 1
 
 heartbeatInterval: 180
 
-payerSecret: ""
-payerSecretKey: ""
+payerSecretKey: "SOLANA_KEY"
 
 rpcUrl: ""
 wssRpcUrl: ""
 solanaMainnetRpc: ""
 
-jupiterSwapApiKey: ""
+jupiterSwapApiKeySecret:
+  name: "jupiter-swap-api"
+  key: "api-key"
 
 debug: ""
 verbose: ""
@@ -100,4 +101,3 @@ components:
       requests:
         cpu: "100m"
         memory: "100Mi"
-

--- a/.scripts/helm/charts/on-demand/values.yaml
+++ b/.scripts/helm/charts/on-demand/values.yaml
@@ -13,11 +13,15 @@ payerSecretKey: "SOLANA_KEY"
 
 rpcUrl: ""
 wssRpcUrl: ""
+heartbeatRpcFallbackUrls: ""
 solanaMainnetRpc: ""
 
 jupiterSwapApiKeySecret:
   name: "jupiter-swap-api"
   key: "api-key"
+pagerDutySecret:
+  name: ""
+  key: "routing-key"
 
 debug: ""
 verbose: ""
@@ -57,6 +61,7 @@ components:
   guardian:
     enabled: true
     image: "docker.io/switchboardlabs/guardian"
+    imageDigest: ""
     queue: ""
     key: ""
     port: 8083
@@ -78,6 +83,22 @@ components:
       requests:
         cpu: "200m"
         memory: "100Mi"
+    ephemeralStorage:
+      enabled: false
+      request: "1Gi"
+      limit: "8Gi"
+    remediator:
+      enabled: false
+      schedule: "* * * * *"
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 3
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
+        requests:
+          cpu: "10m"
+          memory: "32Mi"
 
   gateway:
     enabled: true

--- a/.scripts/kubernetes/guardian-fleet-health.sh
+++ b/.scripts/kubernetes/guardian-fleet-health.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+inventory="${GUARDIAN_FLEET_INVENTORY:-}"
+# One pipe-delimited row per host:
+# kube-context|namespace|guardian-ping-url|metrics-url|heartbeat-interval-seconds
+[[ -n "${inventory}" && -r "${inventory}" ]] || {
+  printf "GUARDIAN_FLEET_INVENTORY must name a readable inventory file\n" >&2
+  exit 1
+}
+
+healthy=0
+while IFS='|' read -r context namespace ping_url metrics_url heartbeat_interval; do
+  [[ -n "${context}" ]] || continue
+  [[ "${context}" == \#* ]] && continue
+  if [[ -z "${namespace}" || -z "${ping_url}" || -z "${metrics_url}" ||
+    ! "${heartbeat_interval}" =~ ^[0-9]+$ ]]; then
+    printf "invalid guardian fleet inventory row\n" >&2
+    exit 1
+  fi
+
+  available="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
+  [[ "${available}" == "1" ]] || continue
+
+  curl -fsS --max-time 5 \
+    -H 'content-type: application/json' \
+    --data '{"api_version":"1"}' \
+    "${ping_url}" >/dev/null || continue
+
+  onchain_age="$(
+    curl -fsS --max-time 5 "${metrics_url}" |
+      awk '/switchboard_on_demand_heartbeat_onchain_age_gauge/ && /role="guardian"/ { print $NF; exit }'
+  )" || true
+  [[ "${onchain_age}" =~ ^[0-9]+([.][0-9]+)?$ ]] || continue
+  maximum_age=$((2 * heartbeat_interval + 60))
+  awk -v age="${onchain_age}" -v maximum="${maximum_age}" \
+    'BEGIN { exit !(age <= maximum) }' || continue
+
+  healthy=$((healthy + 1))
+done <"${inventory}"
+
+printf "%s\n" "${healthy}"

--- a/.scripts/kubernetes/guardian-fleet-health.sh
+++ b/.scripts/kubernetes/guardian-fleet-health.sh
@@ -2,42 +2,121 @@
 set -Eeuo pipefail
 
 inventory="${GUARDIAN_FLEET_INVENTORY:-}"
-# One pipe-delimited row per host:
-# kube-context|namespace|guardian-ping-url|metrics-url|heartbeat-interval-seconds
+ssh_key="${SWITCHBOARD_INFRA_SSH_KEY:-}"
+known_hosts="${SWITCHBOARD_INFRA_KNOWN_HOSTS:-}"
+required_cluster="${GUARDIAN_FLEET_CLUSTER:-}"
+
+# One pipe-delimited row per bare-metal host:
+# ssh-host|cluster|namespace|heartbeat-interval-seconds
 [[ -n "${inventory}" && -r "${inventory}" ]] || {
   printf "GUARDIAN_FLEET_INVENTORY must name a readable inventory file\n" >&2
   exit 1
 }
+[[ -n "${ssh_key}" && -r "${ssh_key}" ]] || {
+  printf "SWITCHBOARD_INFRA_SSH_KEY must name a readable SSH private key\n" >&2
+  exit 1
+}
+[[ -n "${known_hosts}" && -r "${known_hosts}" ]] || {
+  printf "SWITCHBOARD_INFRA_KNOWN_HOSTS must name a readable known-hosts file\n" >&2
+  exit 1
+}
+[[ -z "${required_cluster}" || "${required_cluster}" =~ ^(devnet|mainnet)$ ]] || {
+  printf "GUARDIAN_FLEET_CLUSTER must be devnet or mainnet when set\n" >&2
+  exit 1
+}
 
 healthy=0
-while IFS='|' read -r context namespace ping_url metrics_url heartbeat_interval; do
-  [[ -n "${context}" ]] || continue
-  [[ "${context}" == \#* ]] && continue
-  if [[ -z "${namespace}" || -z "${ping_url}" || -z "${metrics_url}" ||
-    ! "${heartbeat_interval}" =~ ^[0-9]+$ ]]; then
+while IFS='|' read -r host cluster namespace heartbeat_interval extra; do
+  [[ -n "${host}" ]] || continue
+  [[ "${host}" == \#* ]] && continue
+  if [[ -n "${extra}" ||
+    ! "${host}" =~ ^[a-zA-Z0-9.-]+$ ||
+    ! "${cluster}" =~ ^(devnet|mainnet)$ ||
+    ! "${namespace}" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ||
+    ! "${heartbeat_interval}" =~ ^[1-9][0-9]*$ ]]; then
     printf "invalid guardian fleet inventory row\n" >&2
     exit 1
   fi
+  [[ -z "${required_cluster}" || "${cluster}" == "${required_cluster}" ]] || continue
 
-  available="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
-    -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
-  [[ "${available}" == "1" ]] || continue
+  if result="$(
+    ssh -n -T \
+      -i "${ssh_key}" \
+      -o IdentityAgent=none \
+      -o IdentitiesOnly=yes \
+      -o BatchMode=yes \
+      -o StrictHostKeyChecking=yes \
+      -o "UserKnownHostsFile=${known_hosts}" \
+      -o ConnectTimeout=6 \
+      -o LogLevel=ERROR \
+      "root@${host}" /bin/bash -s -- \
+      "${namespace}" "${heartbeat_interval}" "${cluster}" <<'REMOTE'
+set -Eeuo pipefail
 
-  curl -fsS --max-time 5 \
-    -H 'content-type: application/json' \
-    --data '{"api_version":"1"}' \
-    "${ping_url}" >/dev/null || continue
+namespace="$1"
+expected_heartbeat_interval="$2"
+expected_cluster="$3"
 
-  onchain_age="$(
-    curl -fsS --max-time 5 "${metrics_url}" |
-      awk '/switchboard_on_demand_heartbeat_onchain_age_gauge/ && /role="guardian"/ { print $NF; exit }'
-  )" || true
-  [[ "${onchain_age}" =~ ^[0-9]+([.][0-9]+)?$ ]] || continue
-  maximum_age=$((2 * heartbeat_interval + 60))
-  awk -v age="${onchain_age}" -v maximum="${maximum_age}" \
-    'BEGIN { exit !(age <= maximum) }' || continue
+deployment="$(
+  k3s kubectl -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.spec.replicas}|{.status.readyReplicas}|{.status.availableReplicas}|{.status.unavailableReplicas}'
+)"
+IFS='|' read -r desired ready available unavailable <<<"${deployment}"
+[[ "${desired}" == "1" && "${ready}" == "1" && "${available}" == "1" ]]
+[[ -z "${unavailable}" || "${unavailable}" == "0" ]]
 
-  healthy=$((healthy + 1))
+deployed_cluster="$(
+  k3s kubectl -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.metadata.labels.cluster}'
+)"
+[[ "${deployed_cluster}" == "${expected_cluster}" ]]
+
+pod_count="$(
+  k3s kubectl -n "${namespace}" get pods -l app=guardian \
+    -o go-template='{{len .items}}'
+)"
+[[ "${pod_count}" == "1" ]]
+
+pod="$(
+  k3s kubectl -n "${namespace}" get pods -l app=guardian \
+    -o jsonpath='{.items[0].status.podIP}|{.items[0].status.conditions[?(@.type=="Ready")].status}|{.items[0].status.containerStatuses[0].restartCount}'
+)"
+IFS='|' read -r pod_ip pod_ready restart_count <<<"${pod}"
+[[ -n "${pod_ip}" && "${pod_ready}" == "True" && "${restart_count}" =~ ^[0-9]+$ ]]
+
+guardian_port="$(
+  k3s kubectl -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="GUARDIAN_PORT")].value}'
+)"
+[[ "${guardian_port}" =~ ^[1-9][0-9]*$ ]]
+heartbeat_interval="$(
+  k3s kubectl -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="HEARTBEAT_INTERVAL")].value}'
+)"
+[[ "${heartbeat_interval}" =~ ^[1-9][0-9]*$ ]]
+[[ "${heartbeat_interval}" == "${expected_heartbeat_interval}" ]]
+
+curl -fsS --max-time 5 \
+  -H 'content-type: application/json' \
+  --data '{"api_version":"1"}' \
+  "http://${pod_ip}:${guardian_port}/guardian/api/v1/test" >/dev/null
+
+onchain_age="$(
+  curl -fsS --max-time 5 "http://${pod_ip}:9090/metrics" |
+    awk '/switchboard_on_demand_heartbeat_onchain_age_gauge/ && /role="guardian"/ { print $NF; exit }'
+)"
+[[ "${onchain_age}" =~ ^[0-9]+([.][0-9]+)?$ ]]
+maximum_age=$((2 * heartbeat_interval + 60))
+awk -v age="${onchain_age}" -v maximum="${maximum_age}" \
+  'BEGIN { exit !(age <= maximum) }'
+
+printf "1\n"
+REMOTE
+  )" && [[ "${result}" == "1" ]]; then
+    healthy=$((healthy + 1))
+  else
+    printf "guardian host %s is not fleet-healthy\n" "${host}" >&2
+  fi
 done <"${inventory}"
 
 printf "%s\n" "${healthy}"

--- a/.scripts/kubernetes/guardian-rollout-one.sh
+++ b/.scripts/kubernetes/guardian-rollout-one.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+target_host="${1:-}"
+cluster="${2:-}"
+image_digest="${GUARDIAN_IMAGE_DIGEST:-}"
+remediator_enabled="${GUARDIAN_REMEDIATOR_ENABLED:-false}"
+ephemeral_storage_enabled="${GUARDIAN_EPHEMERAL_STORAGE_ENABLED:-false}"
+fallback_enabled="${GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED:-true}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+health_script="${script_dir}/guardian-fleet-health.sh"
+ssh_key="${SWITCHBOARD_INFRA_SSH_KEY:-}"
+known_hosts="${SWITCHBOARD_INFRA_KNOWN_HOSTS:-}"
+
+fail() {
+  printf "ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+[[ "${target_host}" =~ ^[a-zA-Z0-9.-]+$ ]] ||
+  fail "target host must be an explicit hostname or IPv4 address"
+[[ "${cluster}" == "devnet" || "${cluster}" == "mainnet" ]] ||
+  fail "cluster must be devnet or mainnet"
+[[ "${image_digest}" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail "GUARDIAN_IMAGE_DIGEST must be an immutable sha256 digest"
+[[ "${remediator_enabled}" == "true" || "${remediator_enabled}" == "false" ]] ||
+  fail "GUARDIAN_REMEDIATOR_ENABLED must be true or false"
+[[ "${ephemeral_storage_enabled}" == "true" || "${ephemeral_storage_enabled}" == "false" ]] ||
+  fail "GUARDIAN_EPHEMERAL_STORAGE_ENABLED must be true or false"
+[[ "${fallback_enabled}" == "true" || "${fallback_enabled}" == "false" ]] ||
+  fail "GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED must be true or false"
+[[ -n "${ssh_key}" && -r "${ssh_key}" ]] ||
+  fail "SWITCHBOARD_INFRA_SSH_KEY must name a readable SSH private key"
+[[ -n "${known_hosts}" && -r "${known_hosts}" ]] ||
+  fail "SWITCHBOARD_INFRA_KNOWN_HOSTS must name a readable known-hosts file"
+[[ -x "${health_script}" ]] || fail "guardian fleet health checker is not executable"
+[[ -n "${GUARDIAN_FLEET_INVENTORY:-}" && -r "${GUARDIAN_FLEET_INVENTORY}" ]] ||
+  fail "GUARDIAN_FLEET_INVENTORY must name a readable inventory file"
+awk -F '|' -v target="${target_host}" -v expected_cluster="${cluster}" \
+  '$1 == target && $2 == expected_cluster { found = 1 } END { exit !found }' \
+  "${GUARDIAN_FLEET_INVENTORY}" ||
+  fail "target host is not assigned to ${cluster} in GUARDIAN_FLEET_INVENTORY"
+
+check_fleet() {
+  local healthy
+  healthy="$(GUARDIAN_FLEET_CLUSTER="${cluster}" "${health_script}")"
+  [[ "${healthy}" =~ ^[0-9]+$ ]] || fail "fleet health checker did not return an integer"
+  ((healthy >= 5)) || fail "only ${healthy} fleet-healthy guardians; at least 5 are required"
+  printf "%s\n" "${healthy}"
+}
+
+healthy_before="$(check_fleet)"
+attested_at="$(date +%s)"
+
+ssh -n -T \
+  -i "${ssh_key}" \
+  -o IdentityAgent=none \
+  -o IdentitiesOnly=yes \
+  -o BatchMode=yes \
+  -o StrictHostKeyChecking=yes \
+  -o "UserKnownHostsFile=${known_hosts}" \
+  -o ConnectTimeout=6 \
+  -o LogLevel=ERROR \
+  "root@${target_host}" /bin/bash -s -- \
+  "${cluster}" \
+  "${image_digest}" \
+  "${remediator_enabled}" \
+  "${ephemeral_storage_enabled}" \
+  "${fallback_enabled}" \
+  "${healthy_before}" \
+  "${attested_at}" <<'REMOTE'
+set -Eeuo pipefail
+
+cluster="$1"
+image_digest="$2"
+remediator_enabled="$3"
+ephemeral_storage_enabled="$4"
+fallback_enabled="$5"
+healthy_before="$6"
+attested_at="$7"
+repo_dir="/root/infra-external"
+
+[[ -d "${repo_dir}/.git" ]]
+[[ -z "$(git -C "${repo_dir}" status --porcelain --untracked-files=all)" ]]
+upstream="$(git -C "${repo_dir}" rev-parse --abbrev-ref '@{upstream}')"
+git -C "${repo_dir}" fetch
+local_head="$(git -C "${repo_dir}" rev-parse HEAD)"
+upstream_head="$(git -C "${repo_dir}" rev-parse "${upstream}")"
+git -C "${repo_dir}" merge-base --is-ancestor "${local_head}" "${upstream_head}"
+git -C "${repo_dir}" merge --ff-only "${upstream}"
+
+export GUARDIAN_IMAGE_DIGEST="${image_digest}"
+export GUARDIAN_REMEDIATOR_ENABLED="${remediator_enabled}"
+export GUARDIAN_EPHEMERAL_STORAGE_ENABLED="${ephemeral_storage_enabled}"
+export GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED="${fallback_enabled}"
+export GUARDIAN_FLEET_HEALTH_COUNT="${healthy_before}"
+export GUARDIAN_FLEET_HEALTH_ATTESTED_AT="${attested_at}"
+exec "${repo_dir}/.scripts/kubernetes/k8s-oracle-install.sh" "${cluster}"
+REMOTE
+
+healthy_after="$(check_fleet)"
+printf "guardian rollout completed on %s; fleet healthy before=%s after=%s\n" \
+  "${target_host}" "${healthy_before}" "${healthy_after}"

--- a/.scripts/kubernetes/k8s-oracle-install.sh
+++ b/.scripts/kubernetes/k8s-oracle-install.sh
@@ -99,10 +99,37 @@ ensure_namespace() {
   fi
 }
 
-ensure_payer_secret() {
+validate_secret_inputs() {
+  if [[ -n "${PAYER_SECRET_KEY:-}" ]]; then
+    local payer_file="${repo_dir}/data/${cluster}_payer.json"
+    [[ -r "${payer_file}" ]] || fail "payer key file is missing or unreadable"
+  fi
+
+  if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
+    [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] ||
+      fail "JUPITER_SWAP_API_KEY_FILE is unreadable"
+  else
+    kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+      -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" 2>/dev/null |
+      grep -q . ||
+      fail "${JUPITER_SWAP_API_KEY_SECRET_NAME} is missing or lacks the configured key; set JUPITER_SWAP_API_KEY_FILE"
+  fi
+
+  [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
+  if [[ -n "${PAGERDUTY_ROUTING_KEY_FILE:-}" ]]; then
+    [[ -r "${PAGERDUTY_ROUTING_KEY_FILE}" ]] ||
+      fail "PAGERDUTY_ROUTING_KEY_FILE is unreadable"
+  else
+    kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET_NAME}" \
+      -o "jsonpath={.data.${PAGERDUTY_SECRET_KEY}}" 2>/dev/null |
+      grep -q . ||
+      fail "${PAGERDUTY_SECRET_NAME} is missing or lacks the configured key; set PAGERDUTY_ROUTING_KEY_FILE"
+  fi
+}
+
+provision_payer_secret() {
   [[ -n "${PAYER_SECRET_KEY:-}" ]] || return 0
   local payer_file="${repo_dir}/data/${cluster}_payer.json"
-  [[ -r "${payer_file}" ]] || fail "payer key file is missing or unreadable"
   kubectl -n "${NAMESPACE}" create secret generic payer-secret \
     --from-file="${PAYER_SECRET_KEY}=${payer_file}" \
     --dry-run=client -o yaml |
@@ -112,37 +139,27 @@ ensure_payer_secret() {
     grep -q . || fail "payer-secret does not contain the configured key"
 }
 
-ensure_jupiter_secret() {
+provision_jupiter_secret() {
   if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
-    [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] ||
-      fail "JUPITER_SWAP_API_KEY_FILE is unreadable"
     kubectl -n "${NAMESPACE}" create secret generic \
       "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
       --from-file="${JUPITER_SWAP_API_KEY_SECRET_KEY}=${JUPITER_SWAP_API_KEY_FILE}" \
       --dry-run=client -o yaml |
       kubectl apply -f -
-  elif ! kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
-    >/dev/null 2>&1; then
-    fail "${JUPITER_SWAP_API_KEY_SECRET_NAME} is missing; set JUPITER_SWAP_API_KEY_FILE to a replacement credential file"
   fi
   kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
     -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" |
     grep -q . || fail "Jupiter API Secret does not contain the configured key"
 }
 
-ensure_pagerduty_secret() {
+provision_pagerduty_secret() {
   [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
   if [[ -n "${PAGERDUTY_ROUTING_KEY_FILE:-}" ]]; then
-    [[ -r "${PAGERDUTY_ROUTING_KEY_FILE}" ]] ||
-      fail "PAGERDUTY_ROUTING_KEY_FILE is unreadable"
     kubectl -n "${NAMESPACE}" create secret generic \
       "${PAGERDUTY_SECRET_NAME}" \
       --from-file="${PAGERDUTY_SECRET_KEY}=${PAGERDUTY_ROUTING_KEY_FILE}" \
       --dry-run=client -o yaml |
       kubectl apply -f -
-  elif ! kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET_NAME}" \
-    >/dev/null 2>&1; then
-    fail "${PAGERDUTY_SECRET_NAME} is missing; set PAGERDUTY_ROUTING_KEY_FILE to provision it"
   fi
   kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET_NAME}" \
     -o "jsonpath={.data.${PAGERDUTY_SECRET_KEY}}" |
@@ -177,15 +194,21 @@ check_guardian_release_safety() {
   fi
 }
 
-run_fleet_health_gate() {
+verify_fleet_health_attestation() {
   [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
-  local checker="${GUARDIAN_FLEET_HEALTH_COMMAND:-${script_dir}/guardian-fleet-health.sh}"
-  [[ -x "${checker}" ]] ||
-    fail "GUARDIAN_FLEET_HEALTH_COMMAND must name an executable health checker"
-  local healthy
-  healthy="$("${checker}")"
-  [[ "${healthy}" =~ ^[0-9]+$ ]] || fail "fleet health checker did not return an integer"
-  ((healthy >= 5)) || fail "only ${healthy} fleet-healthy guardians; at least 5 are required"
+  local healthy="${GUARDIAN_FLEET_HEALTH_COUNT:-}"
+  local attested_at="${GUARDIAN_FLEET_HEALTH_ATTESTED_AT:-}"
+  local now age
+  [[ "${healthy}" =~ ^[0-9]+$ ]] ||
+    fail "guardian rollout requires a fleet-health assertion from guardian-rollout-one.sh"
+  ((healthy >= 5)) ||
+    fail "fleet-health assertion contains only ${healthy} healthy guardians"
+  [[ "${attested_at}" =~ ^[0-9]+$ ]] ||
+    fail "guardian rollout requires a timestamped fleet-health assertion"
+  now="$(date +%s)"
+  age=$((now - attested_at))
+  ((age >= 0 && age <= 180)) ||
+    fail "fleet-health assertion is stale; rerun guardian-rollout-one.sh"
 }
 
 check_repo_drift
@@ -206,18 +229,20 @@ load_vars "${landing_tmp_helm_file}"
 set -u
 
 check_cluster_access
-ensure_namespace
-ensure_payer_secret
-ensure_jupiter_secret
-ensure_pagerduty_secret
 check_guardian_release_safety
-run_fleet_health_gate
+verify_fleet_health_attestation
+validate_secret_inputs
 
 helm lint "${helm_on_demand_chart_dir}" -f "${tmp_helm_file}" \
   --set-string "heartbeatRpcFallbackUrls=${heartbeat_rpc_fallback_urls}" \
   --set-string "components.guardian.imageDigest=${GUARDIAN_IMAGE_DIGEST}" \
   --set "components.guardian.remediator.enabled=${GUARDIAN_REMEDIATOR_ENABLED}" \
   --set "components.guardian.ephemeralStorage.enabled=${GUARDIAN_EPHEMERAL_STORAGE_ENABLED}"
+
+ensure_namespace
+provision_payer_secret
+provision_jupiter_secret
+provision_pagerduty_secret
 
 printf "HELM: installing Switchboard Oracle under namespace %s\n" "${NAMESPACE}"
 helm upgrade --install "sb-oracle-${NETWORK}" \
@@ -245,7 +270,6 @@ printf "HELM: Switchboard Oracle installed under namespace %s\n" "${NAMESPACE}"
 
 if [[ "${GUARDIAN_ENABLED}" == "true" ]]; then
   kubectl rollout status deployment/guardian -n "${NAMESPACE}" --timeout=10m
-  run_fleet_health_gate
 fi
 
 if [[ "${LANDING_ENABLED:-}" == "true" ]]; then

--- a/.scripts/kubernetes/k8s-oracle-install.sh
+++ b/.scripts/kubernetes/k8s-oracle-install.sh
@@ -1,150 +1,267 @@
 #!/usr/bin/env bash
-set -u -e
+set -Eeuo pipefail
 
 cluster="${1:-devnet}"
-
-set +u
-if [[ -z "${1}" ]]; then
+if [[ $# -eq 0 ]]; then
   printf "No cluster specified, using default: 'devnet'\n"
 fi
-set -u
-
-if [[ "${cluster}" != "devnet" &&
-  "${cluster}" != "mainnet" ]]; then
-  printf "Only valid cluster values are 'devnet' and 'mainnet'.\n"
+if [[ "${cluster}" != "devnet" && "${cluster}" != "mainnet" ]]; then
+  printf "Only valid cluster values are 'devnet' and 'mainnet'.\n" >&2
   exit 1
 fi
 
-export GUARDIAN_ENABLED="true"
+export GUARDIAN_ENABLED="${GUARDIAN_ENABLED:-true}"
+export GUARDIAN_IMAGE_DIGEST="${GUARDIAN_IMAGE_DIGEST:-}"
+export GUARDIAN_REMEDIATOR_ENABLED="${GUARDIAN_REMEDIATOR_ENABLED:-false}"
+export GUARDIAN_EPHEMERAL_STORAGE_ENABLED="${GUARDIAN_EPHEMERAL_STORAGE_ENABLED:-false}"
+export GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED="${GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED:-true}"
 export JUPITER_SWAP_API_KEY_SECRET_NAME="${JUPITER_SWAP_API_KEY_SECRET_NAME:-jupiter-swap-api}"
 export JUPITER_SWAP_API_KEY_SECRET_KEY="${JUPITER_SWAP_API_KEY_SECRET_KEY:-api-key}"
+export PAGERDUTY_SECRET_NAME="${PAGERDUTY_SECRET_NAME:-guardian-pagerduty}"
+export PAGERDUTY_SECRET_KEY="${PAGERDUTY_SECRET_KEY:-routing-key}"
 
-# defaults - these variables can be changed via `cfg/` files
-export DEVNET_DOCKER_IMAGE_TAG="devnet"
-export MAINNET_DOCKER_IMAGE_TAG="stable"
-export V2_DOCKER_IMAGE_TAG="v2-on-v3"
-export ORACLE_DOCKER_IMAGE="docker.io/switchboardlabs/oracle"
-export GUARDIAN_DOCKER_IMAGE="docker.io/switchboardlabs/guardian"
-export GATEWAY_DOCKER_IMAGE="docker.io/switchboardlabs/gateway"
-export OTLP_ENDPOINT="http://sb-log-forwarding-alloy.sb-log-forwarding.svc.cluster.local:4317"
+export DEVNET_DOCKER_IMAGE_TAG="${DEVNET_DOCKER_IMAGE_TAG:-devnet}"
+export MAINNET_DOCKER_IMAGE_TAG="${MAINNET_DOCKER_IMAGE_TAG:-stable}"
+export V2_DOCKER_IMAGE_TAG="${V2_DOCKER_IMAGE_TAG:-v2-on-v3}"
+export ORACLE_DOCKER_IMAGE="${ORACLE_DOCKER_IMAGE:-docker.io/switchboardlabs/oracle}"
+export GUARDIAN_DOCKER_IMAGE="${GUARDIAN_DOCKER_IMAGE:-docker.io/switchboardlabs/guardian}"
+export GATEWAY_DOCKER_IMAGE="${GATEWAY_DOCKER_IMAGE:-docker.io/switchboardlabs/gateway}"
+export OTLP_ENDPOINT="${OTLP_ENDPOINT:-http://sb-log-forwarding-alloy.sb-log-forwarding.svc.cluster.local:4317}"
 
-repo_dir="$(readlink -f ../../..)"
+if [[ "${cluster}" == "devnet" ]]; then
+  public_heartbeat_fallback="https://api.devnet.solana.com"
+else
+  public_heartbeat_fallback="https://api.mainnet-beta.solana.com"
+fi
+if [[ "${GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED}" == "true" ]]; then
+  heartbeat_rpc_fallback_urls="${public_heartbeat_fallback}"
+elif [[ "${GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED}" == "false" ]]; then
+  heartbeat_rpc_fallback_urls=""
+else
+  printf "GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED must be true or false\n" >&2
+  exit 1
+fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "${script_dir}/../.." && pwd)"
 cfg_dir="${repo_dir}/cfg"
 cfg_common_file="${cfg_dir}/00-common-vars.cfg"
 cfg_cluster_file="${cfg_dir}/00-${cluster}-vars.cfg"
+helm_dir="${repo_dir}/.scripts/helm"
+helm_on_demand_chart_dir="${helm_dir}/charts/on-demand"
+helm_landing_page_chart_dir="${helm_dir}/charts/oracle-landing-page"
+helm_values_file="${helm_dir}/cfg/${cluster}-solana-values.yaml"
+helm_landing_values_file="${helm_dir}/cfg/oracle-landing-page-values.yaml"
+tmp_dir="$(mktemp -d)"
+tmp_helm_file="${tmp_dir}/helm-values.yaml"
+landing_tmp_helm_file="${tmp_dir}/landing-values.yaml"
 
-# import vars
-source "${cfg_common_file}"
-source "${cfg_cluster_file}"
+cleanup() {
+  rm -f "${tmp_helm_file}" "${landing_tmp_helm_file}"
+  rmdir "${tmp_dir}" 2>/dev/null || true
+}
+trap cleanup EXIT
 
-printf "\n"
-printf "==========================================================================\n"
-printf "\n"
+fail() {
+  printf "ERROR: %s\n" "$*" >&2
+  exit 1
+}
 
-if [[ "$(kubectl get ns | grep -e '^'${NAMESPACE}'\W')" == "" ]]; then
-  printf "KUBECTL: creating Namespace ${NAMESPACE}\n"
-  kubectl create namespace "${NAMESPACE}"
-  printf "KUBECTL: Namespace ${NAMESPACE} created\n"
-fi
+check_repo_drift() {
+  local changes upstream local_head upstream_head
+  changes="$(git -C "${repo_dir}" status --porcelain --untracked-files=all)"
+  [[ -z "${changes}" ]] || fail "repository has machine-local drift; refusing to deploy"
 
-if [[ "${PAYER_SECRET_KEY}" != "" ]]; then
-  payer_file="${repo_dir}/data/${cluster}_payer.json"
-  [[ -r "${payer_file}" ]] || {
-    printf "payer key file is missing or unreadable\n" >&2
-    exit 1
-  }
+  upstream="$(git -C "${repo_dir}" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "${upstream}" ]]; then
+    local_head="$(git -C "${repo_dir}" rev-parse HEAD)"
+    upstream_head="$(git -C "${repo_dir}" rev-parse "${upstream}")"
+    [[ "${local_head}" == "${upstream_head}" ]] ||
+      fail "repository is not at its recorded upstream commit; update by fast-forward only"
+  fi
+}
+
+check_cluster_access() {
+  local context
+  context="$(kubectl config current-context)"
+  [[ -n "${context}" ]] || fail "kubectl has no current context"
+  kubectl cluster-info >/dev/null
+  kubectl auth can-i get pods --all-namespaces | grep -qx "yes" ||
+    fail "current Kubernetes identity cannot inspect pods"
+  kubectl auth can-i patch deployments.apps -n "${NAMESPACE}" | grep -qx "yes" ||
+    fail "current Kubernetes identity cannot patch Deployments in ${NAMESPACE}"
+}
+
+ensure_namespace() {
+  if ! kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    printf "KUBECTL: creating namespace %s\n" "${NAMESPACE}"
+    kubectl create namespace "${NAMESPACE}"
+  fi
+}
+
+ensure_payer_secret() {
+  [[ -n "${PAYER_SECRET_KEY:-}" ]] || return 0
+  local payer_file="${repo_dir}/data/${cluster}_payer.json"
+  [[ -r "${payer_file}" ]] || fail "payer key file is missing or unreadable"
   kubectl -n "${NAMESPACE}" create secret generic payer-secret \
     --from-file="${PAYER_SECRET_KEY}=${payer_file}" \
     --dry-run=client -o yaml |
     kubectl apply -f -
   kubectl -n "${NAMESPACE}" get secret payer-secret \
     -o "jsonpath={.data.${PAYER_SECRET_KEY}}" |
-    grep -q . || {
-    printf "payer-secret does not contain the configured key\n" >&2
-    exit 1
-  }
-fi
-
-if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
-  [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] || {
-    printf "JUPITER_SWAP_API_KEY_FILE is unreadable\n" >&2
-    exit 1
-  }
-  kubectl -n "${NAMESPACE}" create secret generic \
-    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
-    --from-file="${JUPITER_SWAP_API_KEY_SECRET_KEY}=${JUPITER_SWAP_API_KEY_FILE}" \
-    --dry-run=client -o yaml |
-    kubectl apply -f -
-elif ! kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
-  >/dev/null 2>&1; then
-  printf "%s is missing; set JUPITER_SWAP_API_KEY_FILE to provision the replacement credential\n" \
-    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" >&2
-  exit 1
-fi
-kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
-  -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" |
-  grep -q . || {
-  printf "Jupiter API Secret does not contain the configured key\n" >&2
-  exit 1
+    grep -q . || fail "payer-secret does not contain the configured key"
 }
 
-helm_dir="${repo_dir}/.scripts/helm/"
-helm_charts_dir="${helm_dir}/charts/"
-helm_on_demand_chart_dir="${helm_charts_dir}/on-demand/"
-helm_landing_page_chart_dir="${helm_charts_dir}/oracle-landing-page/"
-helm_values_file="${helm_dir}/cfg/${cluster}-solana-values.yaml"
-helm_landing_values_file="${helm_dir}/cfg/oracle-landing-page-values.yaml"
-tmp_helm_file="/tmp/helm_values.yaml"
-landing_tmp_helm_file="/tmp/helm_landing_values.yaml"
+ensure_jupiter_secret() {
+  if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
+    [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] ||
+      fail "JUPITER_SWAP_API_KEY_FILE is unreadable"
+    kubectl -n "${NAMESPACE}" create secret generic \
+      "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+      --from-file="${JUPITER_SWAP_API_KEY_SECRET_KEY}=${JUPITER_SWAP_API_KEY_FILE}" \
+      --dry-run=client -o yaml |
+      kubectl apply -f -
+  elif ! kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+    >/dev/null 2>&1; then
+    fail "${JUPITER_SWAP_API_KEY_SECRET_NAME} is missing; set JUPITER_SWAP_API_KEY_FILE to a replacement credential file"
+  fi
+  kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+    -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" |
+    grep -q . || fail "Jupiter API Secret does not contain the configured key"
+}
+
+ensure_pagerduty_secret() {
+  [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
+  if [[ -n "${PAGERDUTY_ROUTING_KEY_FILE:-}" ]]; then
+    [[ -r "${PAGERDUTY_ROUTING_KEY_FILE}" ]] ||
+      fail "PAGERDUTY_ROUTING_KEY_FILE is unreadable"
+    kubectl -n "${NAMESPACE}" create secret generic \
+      "${PAGERDUTY_SECRET_NAME}" \
+      --from-file="${PAGERDUTY_SECRET_KEY}=${PAGERDUTY_ROUTING_KEY_FILE}" \
+      --dry-run=client -o yaml |
+      kubectl apply -f -
+  elif ! kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET_NAME}" \
+    >/dev/null 2>&1; then
+    fail "${PAGERDUTY_SECRET_NAME} is missing; set PAGERDUTY_ROUTING_KEY_FILE to provision it"
+  fi
+  kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET_NAME}" \
+    -o "jsonpath={.data.${PAGERDUTY_SECRET_KEY}}" |
+    grep -q . || fail "PagerDuty Secret does not contain the configured key"
+}
+
+check_guardian_release_safety() {
+  [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
+  [[ "${GUARDIAN_IMAGE_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+    fail "GUARDIAN_IMAGE_DIGEST must be an immutable sha256 digest"
+
+  local primary fallback primary_authority fallback_authority
+  primary="${RPC_URL%/}"
+  if [[ "${GUARDIAN_PUBLIC_RPC_FALLBACK_ENABLED}" == "true" ]]; then
+    fallback="${public_heartbeat_fallback}"
+    primary_authority="${primary#*://}"
+    primary_authority="${primary_authority%%/*}"
+    primary_authority="${primary_authority##*@}"
+    primary_authority="${primary_authority%%:*}"
+    primary_authority="${primary_authority,,}"
+    fallback_authority="${fallback#*://}"
+    fallback_authority="${fallback_authority%%/*}"
+    fallback_authority="${fallback_authority%%:*}"
+    fallback_authority="${fallback_authority,,}"
+    [[ "${primary}" != "${fallback}" && "${primary_authority}" != "${fallback_authority}" ]] ||
+      fail "guardian primary RPC must differ from the public heartbeat fallback"
+  fi
+
+  if [[ "${GUARDIAN_REMEDIATOR_ENABLED}" == "true" ]]; then
+    kubectl auth can-i patch deployment/guardian -n "${NAMESPACE}" | grep -qx "yes" ||
+      fail "current Kubernetes identity cannot patch deployment/guardian"
+  fi
+}
+
+run_fleet_health_gate() {
+  [[ "${GUARDIAN_ENABLED}" == "true" ]] || return 0
+  local checker="${GUARDIAN_FLEET_HEALTH_COMMAND:-${script_dir}/guardian-fleet-health.sh}"
+  [[ -x "${checker}" ]] ||
+    fail "GUARDIAN_FLEET_HEALTH_COMMAND must name an executable health checker"
+  local healthy
+  healthy="$("${checker}")"
+  [[ "${healthy}" =~ ^[0-9]+$ ]] || fail "fleet health checker did not return an integer"
+  ((healthy >= 5)) || fail "only ${healthy} fleet-healthy guardians; at least 5 are required"
+}
+
+check_repo_drift
+
+# shellcheck source=/dev/null
+source "${cfg_common_file}"
+# shellcheck source=/dev/null
+source "${cfg_cluster_file}"
 
 cp "${helm_values_file}" "${tmp_helm_file}"
 cp "${helm_landing_values_file}" "${landing_tmp_helm_file}"
 
-source "${repo_dir}"/.scripts/var/_load_vars.sh
+# shellcheck source=/dev/null
+source "${repo_dir}/.scripts/var/_load_vars.sh"
 set +u
-load_vars "${tmp_helm_file}" >/dev/null 2>&1
-load_vars "${landing_tmp_helm_file}" >/dev/null 2>&1
+load_vars "${tmp_helm_file}"
+load_vars "${landing_tmp_helm_file}"
+set -u
 
-sgx_data_dir="${repo_dir}/data/${cluster}_protected_files"
-if [ ! -d "${repo_dir}" ]; then
-  mkdir "${repo_dir}"
-fi
+check_cluster_access
+ensure_namespace
+ensure_payer_secret
+ensure_jupiter_secret
+ensure_pagerduty_secret
+check_guardian_release_safety
+run_fleet_health_gate
 
-printf "HELM: Installing Switchboard Oracle under namespace ${NAMESPACE}\n"
-helm upgrade -i "sb-oracle-${NETWORK}" \
+helm lint "${helm_on_demand_chart_dir}" -f "${tmp_helm_file}" \
+  --set-string "heartbeatRpcFallbackUrls=${heartbeat_rpc_fallback_urls}" \
+  --set-string "components.guardian.imageDigest=${GUARDIAN_IMAGE_DIGEST}" \
+  --set "components.guardian.remediator.enabled=${GUARDIAN_REMEDIATOR_ENABLED}" \
+  --set "components.guardian.ephemeralStorage.enabled=${GUARDIAN_EPHEMERAL_STORAGE_ENABLED}"
+
+printf "HELM: installing Switchboard Oracle under namespace %s\n" "${NAMESPACE}"
+helm upgrade --install "sb-oracle-${NETWORK}" \
   -n "${NAMESPACE}" --create-namespace \
   -f "${tmp_helm_file}" \
-  --set tracing.otlpEndpoint="${OTLP_ENDPOINT}" \
-  --set components.docker_image_tag="${DOCKER_IMAGE_TAG}" \
-  --set components.oracle.enabled=${ORACLE_ENABLED} \
-  --set components.oracle.image="${ORACLE_DOCKER_IMAGE}" \
-  --set components.guardian.enabled=${GUARDIAN_ENABLED} \
-  --set components.guardian.image="${GUARDIAN_DOCKER_IMAGE}" \
-  --set components.gateway.enabled=${GATEWAY_ENABLED} \
-  --set components.gateway.image="${GATEWAY_DOCKER_IMAGE}" \
-  --set-string jupiterSwapApiKeySecret.name="${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
-  --set-string jupiterSwapApiKeySecret.key="${JUPITER_SWAP_API_KEY_SECRET_KEY}" \
-  "${helm_on_demand_chart_dir}" >/dev/null
-printf "HELM: Switchboard Oracle installed under namespace ${NAMESPACE}\n"
+  --set-string "heartbeatRpcFallbackUrls=${heartbeat_rpc_fallback_urls}" \
+  --set-string "tracing.otlpEndpoint=${OTLP_ENDPOINT}" \
+  --set-string "components.docker_image_tag=${DOCKER_IMAGE_TAG}" \
+  --set "components.oracle.enabled=${ORACLE_ENABLED}" \
+  --set-string "components.oracle.image=${ORACLE_DOCKER_IMAGE}" \
+  --set "components.guardian.enabled=${GUARDIAN_ENABLED}" \
+  --set-string "components.guardian.image=${GUARDIAN_DOCKER_IMAGE}" \
+  --set-string "components.guardian.imageDigest=${GUARDIAN_IMAGE_DIGEST}" \
+  --set "components.guardian.remediator.enabled=${GUARDIAN_REMEDIATOR_ENABLED}" \
+  --set "components.guardian.ephemeralStorage.enabled=${GUARDIAN_EPHEMERAL_STORAGE_ENABLED}" \
+  --set "components.gateway.enabled=${GATEWAY_ENABLED}" \
+  --set-string "components.gateway.image=${GATEWAY_DOCKER_IMAGE}" \
+  --set-string "jupiterSwapApiKeySecret.name=${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  --set-string "jupiterSwapApiKeySecret.key=${JUPITER_SWAP_API_KEY_SECRET_KEY}" \
+  --set-string "pagerDutySecret.name=${PAGERDUTY_SECRET_NAME}" \
+  --set-string "pagerDutySecret.key=${PAGERDUTY_SECRET_KEY}" \
+  --atomic --wait --timeout 10m \
+  "${helm_on_demand_chart_dir}"
+printf "HELM: Switchboard Oracle installed under namespace %s\n" "${NAMESPACE}"
 
-if [[ "${LANDING_ENABLED}" != "" && "${LANDING_ENABLED}" == "true" ]]; then
-  printf "HELM: Installing Switchboard Landing page under namespace ${LANDING_NAMESPACE}\n"
-  helm upgrade -i "oracle-landing-page" \
-    -n "${LANDING_NAMESPACE}" --create-namespace \
-    -f "${landing_tmp_helm_file}" \
-    --set oracle_landing_page.namespace="${LANDING_NAMESPACE}" \
-    --set oracle_landing_page.image="${LANDING_IMAGE}" \
-    --set oracle_landing_page.image_tag="${LANDING_IMAGE_TAG}" \
-    --set oracle_landing_page.ingress.host="${CLUSTER_DOMAIN}" \
-    --set guardian.devnet.enabled=${GUARDIAN_ENABLED} \
-    --set guardian.mainnet.enabled=${GUARDIAN_ENABLED} \
-    --set oracle.devnet.enabled=${ORACLE_ENABLED} \
-    --set oracle.mainnet.enabled=${ORACLE_ENABLED} \
-    "${helm_landing_page_chart_dir}" >/dev/null
-  printf "HELM: Switchboard Oracle Landing page installed under namespace ${LANDING_NAMESPACE}\n"
+if [[ "${GUARDIAN_ENABLED}" == "true" ]]; then
+  kubectl rollout status deployment/guardian -n "${NAMESPACE}" --timeout=10m
+  run_fleet_health_gate
 fi
 
-rm "${tmp_helm_file}"
-
-set -u
+if [[ "${LANDING_ENABLED:-}" == "true" ]]; then
+  printf "HELM: installing Switchboard landing page under namespace %s\n" "${LANDING_NAMESPACE}"
+  helm upgrade --install oracle-landing-page \
+    -n "${LANDING_NAMESPACE}" --create-namespace \
+    -f "${landing_tmp_helm_file}" \
+    --set-string "oracle_landing_page.namespace=${LANDING_NAMESPACE}" \
+    --set-string "oracle_landing_page.image=${LANDING_IMAGE}" \
+    --set-string "oracle_landing_page.image_tag=${LANDING_IMAGE_TAG}" \
+    --set-string "oracle_landing_page.ingress.host=${CLUSTER_DOMAIN}" \
+    --set "guardian.devnet.enabled=${GUARDIAN_ENABLED}" \
+    --set "guardian.mainnet.enabled=${GUARDIAN_ENABLED}" \
+    --set "oracle.devnet.enabled=${ORACLE_ENABLED}" \
+    --set "oracle.mainnet.enabled=${ORACLE_ENABLED}" \
+    --atomic --wait --timeout 10m \
+    "${helm_landing_page_chart_dir}"
+  printf "HELM: Switchboard landing page installed under namespace %s\n" "${LANDING_NAMESPACE}"
+fi

--- a/.scripts/kubernetes/k8s-oracle-install.sh
+++ b/.scripts/kubernetes/k8s-oracle-install.sh
@@ -16,6 +16,8 @@ if [[ "${cluster}" != "devnet" &&
 fi
 
 export GUARDIAN_ENABLED="true"
+export JUPITER_SWAP_API_KEY_SECRET_NAME="${JUPITER_SWAP_API_KEY_SECRET_NAME:-jupiter-swap-api}"
+export JUPITER_SWAP_API_KEY_SECRET_KEY="${JUPITER_SWAP_API_KEY_SECRET_KEY:-api-key}"
 
 # defaults - these variables can be changed via `cfg/` files
 export DEVNET_DOCKER_IMAGE_TAG="devnet"
@@ -45,6 +47,47 @@ if [[ "$(kubectl get ns | grep -e '^'${NAMESPACE}'\W')" == "" ]]; then
   kubectl create namespace "${NAMESPACE}"
   printf "KUBECTL: Namespace ${NAMESPACE} created\n"
 fi
+
+if [[ "${PAYER_SECRET_KEY}" != "" ]]; then
+  payer_file="${repo_dir}/data/${cluster}_payer.json"
+  [[ -r "${payer_file}" ]] || {
+    printf "payer key file is missing or unreadable\n" >&2
+    exit 1
+  }
+  kubectl -n "${NAMESPACE}" create secret generic payer-secret \
+    --from-file="${PAYER_SECRET_KEY}=${payer_file}" \
+    --dry-run=client -o yaml |
+    kubectl apply -f -
+  kubectl -n "${NAMESPACE}" get secret payer-secret \
+    -o "jsonpath={.data.${PAYER_SECRET_KEY}}" |
+    grep -q . || {
+    printf "payer-secret does not contain the configured key\n" >&2
+    exit 1
+  }
+fi
+
+if [[ -n "${JUPITER_SWAP_API_KEY_FILE:-}" ]]; then
+  [[ -r "${JUPITER_SWAP_API_KEY_FILE}" ]] || {
+    printf "JUPITER_SWAP_API_KEY_FILE is unreadable\n" >&2
+    exit 1
+  }
+  kubectl -n "${NAMESPACE}" create secret generic \
+    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+    --from-file="${JUPITER_SWAP_API_KEY_SECRET_KEY}=${JUPITER_SWAP_API_KEY_FILE}" \
+    --dry-run=client -o yaml |
+    kubectl apply -f -
+elif ! kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  >/dev/null 2>&1; then
+  printf "%s is missing; set JUPITER_SWAP_API_KEY_FILE to provision the replacement credential\n" \
+    "${JUPITER_SWAP_API_KEY_SECRET_NAME}" >&2
+  exit 1
+fi
+kubectl -n "${NAMESPACE}" get secret "${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  -o "jsonpath={.data.${JUPITER_SWAP_API_KEY_SECRET_KEY}}" |
+  grep -q . || {
+  printf "Jupiter API Secret does not contain the configured key\n" >&2
+  exit 1
+}
 
 helm_dir="${repo_dir}/.scripts/helm/"
 helm_charts_dir="${helm_dir}/charts/"
@@ -80,26 +123,10 @@ helm upgrade -i "sb-oracle-${NETWORK}" \
   --set components.guardian.image="${GUARDIAN_DOCKER_IMAGE}" \
   --set components.gateway.enabled=${GATEWAY_ENABLED} \
   --set components.gateway.image="${GATEWAY_DOCKER_IMAGE}" \
+  --set-string jupiterSwapApiKeySecret.name="${JUPITER_SWAP_API_KEY_SECRET_NAME}" \
+  --set-string jupiterSwapApiKeySecret.key="${JUPITER_SWAP_API_KEY_SECRET_KEY}" \
   "${helm_on_demand_chart_dir}" >/dev/null
 printf "HELM: Switchboard Oracle installed under namespace ${NAMESPACE}\n"
-
-if [[ "${PAYER_SECRET_KEY}" != "" ]]; then
-  printf "KUBECTL: creating secret ${NAMESPACE}/payer-secret\n"
-  # delete pre-existing secret
-  set +e
-  kubectl \
-    -n "${NAMESPACE}" \
-    delete secret payer-secret >/dev/null 2>&1
-  set -e
-
-  # re-create secret
-  kubectl \
-    -n "${NAMESPACE}" \
-    create secret generic \
-    --from-file="${PAYER_SECRET_KEY}=../../../data/${cluster}_payer.json" \
-    payer-secret >/dev/null
-  printf "KUBECTL: secret ${NAMESPACE}/payer-secret created\n"
-fi
 
 if [[ "${LANDING_ENABLED}" != "" && "${LANDING_ENABLED}" == "true" ]]; then
   printf "HELM: Installing Switchboard Landing page under namespace ${LANDING_NAMESPACE}\n"

--- a/.scripts/kubernetes/test-guardian-fleet-health.sh
+++ b/.scripts/kubernetes/test-guardian-fleet-health.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_dir="$(mktemp -d "${script_dir}/.guardian-fleet-test.XXXXXX")"
+trap 'rm -f "${tmp_dir}/inventory" "${tmp_dir}/key" "${tmp_dir}/known_hosts" "${tmp_dir}/ssh" "${tmp_dir}/ssh.log" "${tmp_dir}/rollout.log"; rmdir "${tmp_dir}"' EXIT
+
+touch "${tmp_dir}/key" "${tmp_dir}/known_hosts" "${tmp_dir}/ssh.log"
+cat >"${tmp_dir}/inventory" <<'INVENTORY'
+healthy-1|devnet|switchboard-oracle-devnet|30
+healthy-2|devnet|switchboard-oracle-devnet|30
+healthy-3|devnet|switchboard-oracle-devnet|30
+healthy-4|devnet|switchboard-oracle-devnet|30
+healthy-5|devnet|switchboard-oracle-devnet|30
+unhealthy-1|devnet|switchboard-oracle-devnet|30
+healthy-mainnet-1|mainnet|switchboard-oracle-mainnet|30
+INVENTORY
+cat >"${tmp_dir}/ssh" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf "%s\n" "$*" >>"${MOCK_SSH_LOG}"
+for argument in "$@"; do
+  if [[ "${argument}" == "root@unhealthy-1" ]]; then
+    exit 1
+  fi
+done
+printf "1\n"
+MOCK
+chmod 0755 "${tmp_dir}/ssh"
+
+healthy="$(
+  PATH="${tmp_dir}:${PATH}" \
+    MOCK_SSH_LOG="${tmp_dir}/ssh.log" \
+    GUARDIAN_FLEET_INVENTORY="${tmp_dir}/inventory" \
+    GUARDIAN_FLEET_CLUSTER=devnet \
+    SWITCHBOARD_INFRA_SSH_KEY="${tmp_dir}/key" \
+    SWITCHBOARD_INFRA_KNOWN_HOSTS="${tmp_dir}/known_hosts" \
+    "${script_dir}/guardian-fleet-health.sh"
+)"
+[[ "${healthy}" == "5" ]]
+grep -q -- '-o IdentityAgent=none' "${tmp_dir}/ssh.log"
+grep -q -- '-o IdentitiesOnly=yes' "${tmp_dir}/ssh.log"
+grep -q -- '-o BatchMode=yes' "${tmp_dir}/ssh.log"
+grep -q -- '-o StrictHostKeyChecking=yes' "${tmp_dir}/ssh.log"
+grep -q -- 'k3s' "${script_dir}/guardian-fleet-health.sh"
+grep -q -- 'GUARDIAN_FLEET_CLUSTER="${cluster}"' "${script_dir}/guardian-rollout-one.sh"
+
+if GUARDIAN_FLEET_INVENTORY="${tmp_dir}/inventory" \
+  SWITCHBOARD_INFRA_SSH_KEY="${tmp_dir}/key" \
+  SWITCHBOARD_INFRA_KNOWN_HOSTS="${tmp_dir}/known_hosts" \
+  GUARDIAN_IMAGE_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  "${script_dir}/guardian-rollout-one.sh" healthy-1 mainnet \
+  >"${tmp_dir}/rollout.log" 2>&1; then
+  printf "rollout accepted a host assigned to a different cluster\n" >&2
+  exit 1
+fi
+grep -q -- 'not assigned to mainnet' "${tmp_dir}/rollout.log"
+
+printf "guardian fleet health assertions passed\n"

--- a/.scripts/kubernetes/test-guardian-remediator-k3s.sh
+++ b/.scripts/kubernetes/test-guardian-remediator-k3s.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${1:-}" != "--execute" ]]; then
+  printf "Usage: K3S_TEST_CONTEXT=<context> REMEDIATOR_IMAGE=<image@sha256:digest> %s --execute\n" "$0" >&2
+  exit 2
+fi
+
+context="${K3S_TEST_CONTEXT:-}"
+image="${REMEDIATOR_IMAGE:-}"
+[[ -n "${context}" ]] || {
+  printf "K3S_TEST_CONTEXT is required\n" >&2
+  exit 1
+}
+[[ "${image}" =~ @sha256:[a-f0-9]{64}$ ]] || {
+  printf "REMEDIATOR_IMAGE must be pinned by sha256 digest\n" >&2
+  exit 1
+}
+
+current_context="$(kubectl config current-context)"
+[[ "${current_context}" == "${context}" ]] || {
+  printf "current context %s does not match explicit k3s test context %s\n" \
+    "${current_context}" "${context}" >&2
+  exit 1
+}
+
+namespace="guardian-remediator-test-$(date +%s)"
+cleanup() {
+  kubectl --context "${context}" delete namespace "${namespace}" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+kubectl --context "${context}" create namespace "${namespace}"
+kubectl --context "${context}" -n "${namespace}" apply -f - <<YAML
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: guardian-remediator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: guardian-remediator
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["guardian"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: guardian-remediator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: guardian-remediator
+subjects:
+  - kind: ServiceAccount
+    name: guardian-remediator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guardian
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: guardian
+  template:
+    metadata:
+      labels:
+        app: guardian
+    spec:
+      containers:
+        - name: guardian
+          image: ${image}
+          command: ["/bin/sh", "-c", "sleep 600"]
+          env:
+            - name: INTENTIONAL_CREATE_ERROR
+              valueFrom:
+                configMapKeyRef:
+                  name: intentionally-missing
+                  key: value
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: unrelated-sentinel
+  labels:
+    app: unrelated
+spec:
+  restartPolicy: Never
+  containers:
+    - name: sentinel
+      image: ${image}
+      command: ["/bin/sh", "-c", "sleep 600"]
+YAML
+
+for _ in $(seq 1 60); do
+  pod_uid="$(kubectl --context "${context}" -n "${namespace}" get pods \
+    -l app=guardian -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || true)"
+  create_reason="$(kubectl --context "${context}" -n "${namespace}" get pods \
+    -l app=guardian -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' \
+    2>/dev/null || true)"
+  generation="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.metadata.generation}' 2>/dev/null || true)"
+  observed="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true)"
+  updated="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || true)"
+  if [[ -n "${pod_uid}" && "${create_reason}" == "CreateContainerConfigError" &&
+    "${generation}" == "${observed}" && "${updated}" == "1" ]]; then
+    break
+  fi
+  sleep 2
+done
+[[ -n "${pod_uid:-}" && "${create_reason:-}" == "CreateContainerConfigError" ]] || {
+  printf "guardian test pod did not reach the expected harmless create error\n" >&2
+  exit 1
+}
+
+sentinel_uid="$(kubectl --context "${context}" -n "${namespace}" get pod unrelated-sentinel \
+  -o jsonpath='{.metadata.uid}')"
+first_seen="$(date -u --date='6 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+kubectl --context "${context}" -n "${namespace}" annotate deployment guardian \
+  "guardian.switchboard.xyz/create-error-first-seen=${pod_uid}|${first_seen}"
+
+kubectl --context "${context}" -n "${namespace}" apply -f - <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: guardian-remediator-test
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: guardian-remediator
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      containers:
+        - name: remediator
+          image: ${image}
+          command: ["/app/guardian-remediator"]
+          env:
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GUARDIAN_DEPLOYMENT
+              value: guardian
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+YAML
+
+if ! kubectl --context "${context}" -n "${namespace}" wait \
+  --for=condition=complete job/guardian-remediator-test --timeout=2m; then
+  kubectl --context "${context}" -n "${namespace}" logs job/guardian-remediator-test >&2 || true
+  exit 1
+fi
+
+replacement_uid=""
+for _ in $(seq 1 60); do
+  replacement_uid="$(kubectl --context "${context}" -n "${namespace}" get pods \
+    -l app=guardian -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || true)"
+  [[ -n "${replacement_uid}" && "${replacement_uid}" != "${pod_uid}" ]] && break
+  sleep 2
+done
+[[ -n "${replacement_uid}" && "${replacement_uid}" != "${pod_uid}" ]] || {
+  printf "remediator did not produce a replacement guardian-test Pod UID\n" >&2
+  exit 1
+}
+
+current_sentinel_uid="$(kubectl --context "${context}" -n "${namespace}" \
+  get pod unrelated-sentinel -o jsonpath='{.metadata.uid}')"
+[[ "${current_sentinel_uid}" == "${sentinel_uid}" ]] || {
+  printf "remediator changed an unrelated pod\n" >&2
+  exit 1
+}
+
+printf "guardian remediator k3s integration test passed\n"

--- a/.scripts/kubernetes/test-guardian-remediator-k3s.sh
+++ b/.scripts/kubernetes/test-guardian-remediator-k3s.sh
@@ -63,6 +63,13 @@ subjects:
   - kind: ServiceAccount
     name: guardian-remediator
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: guardian-startup-config
+data:
+  value: present-for-initial-start
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,12 +89,12 @@ spec:
       containers:
         - name: guardian
           image: ${image}
-          command: ["/bin/sh", "-c", "sleep 600"]
+          command: ["/bin/sh", "-ec", "sleep 60; exit 1"]
           env:
-            - name: INTENTIONAL_CREATE_ERROR
+            - name: REQUIRED_STARTUP_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: intentionally-missing
+                  name: guardian-startup-config
                   key: value
 ---
 apiVersion: v1
@@ -107,6 +114,26 @@ YAML
 for _ in $(seq 1 60); do
   pod_uid="$(kubectl --context "${context}" -n "${namespace}" get pods \
     -l app=guardian -o jsonpath='{.items[0].metadata.uid}' 2>/dev/null || true)"
+  ready="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  available="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)"
+  progressing_reason="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o 'jsonpath={.status.conditions[?(@.type=="Progressing")].reason}' 2>/dev/null || true)"
+  if [[ -n "${pod_uid}" && "${ready}" == "1" && "${available}" == "1" &&
+    "${progressing_reason}" == "NewReplicaSetAvailable" ]]; then
+    break
+  fi
+  sleep 2
+done
+[[ -n "${pod_uid:-}" && "${ready:-}" == "1" && "${available:-}" == "1" ]] || {
+  printf "guardian test deployment did not complete its initial healthy rollout\n" >&2
+  exit 1
+}
+
+kubectl --context "${context}" -n "${namespace}" delete configmap guardian-startup-config
+
+for _ in $(seq 1 60); do
   create_reason="$(kubectl --context "${context}" -n "${namespace}" get pods \
     -l app=guardian -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' \
     2>/dev/null || true)"
@@ -116,14 +143,18 @@ for _ in $(seq 1 60); do
     -o jsonpath='{.status.observedGeneration}' 2>/dev/null || true)"
   updated="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
     -o jsonpath='{.status.updatedReplicas}' 2>/dev/null || true)"
+  progressing_reason="$(kubectl --context "${context}" -n "${namespace}" get deployment guardian \
+    -o 'jsonpath={.status.conditions[?(@.type=="Progressing")].reason}' 2>/dev/null || true)"
   if [[ -n "${pod_uid}" && "${create_reason}" == "CreateContainerConfigError" &&
-    "${generation}" == "${observed}" && "${updated}" == "1" ]]; then
+    "${generation}" == "${observed}" && "${updated}" == "1" &&
+    "${progressing_reason}" == "NewReplicaSetAvailable" ]]; then
     break
   fi
   sleep 2
 done
-[[ -n "${pod_uid:-}" && "${create_reason:-}" == "CreateContainerConfigError" ]] || {
-  printf "guardian test pod did not reach the expected harmless create error\n" >&2
+[[ -n "${pod_uid:-}" && "${create_reason:-}" == "CreateContainerConfigError" &&
+  "${progressing_reason:-}" == "NewReplicaSetAvailable" ]] || {
+  printf "guardian test pod did not reach the expected post-rollout create error\n" >&2
   exit 1
 }
 

--- a/.scripts/kubernetes/test-kata-ephemeral-storage.sh
+++ b/.scripts/kubernetes/test-kata-ephemeral-storage.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${1:-}" != "--execute" ]]; then
+  printf "Usage: KATA_TEST_CONTEXT=<context> KATA_STORAGE_TEST_IMAGE=<image@sha256:digest> %s --execute\n" "$0" >&2
+  printf "Creates and removes an isolated Kata namespace and writes 192 MiB in one test container.\n" >&2
+  exit 64
+fi
+
+context="$(kubectl config current-context)"
+expected_context="${KATA_TEST_CONTEXT:-}"
+test_image="${KATA_STORAGE_TEST_IMAGE:-}"
+[[ -n "${expected_context}" && "${context}" == "${expected_context}" ]] || {
+  printf "current context must match explicit KATA_TEST_CONTEXT\n" >&2
+  exit 1
+}
+[[ "${test_image}" =~ @sha256:[a-f0-9]{64}$ ]] || {
+  printf "KATA_STORAGE_TEST_IMAGE must be pinned by sha256 digest\n" >&2
+  exit 1
+}
+kubectl get runtimeclass kata-qemu-snp >/dev/null
+
+namespace="guardian-kata-storage-test-$(date +%s)"
+cleanup() {
+  kubectl delete namespace "${namespace}" --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+kubectl create namespace "${namespace}"
+kubectl apply -n "${namespace}" -f - <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: writable-layer-probe
+spec:
+  runtimeClassName: kata-qemu-snp
+  restartPolicy: Never
+  containers:
+    - name: writer
+      image: ${test_image}
+      command:
+        - sh
+        - -ec
+        - |
+          dd if=/dev/zero of=/rootfs-probe bs=1M count=192
+          sync
+          sleep 600
+      resources:
+        requests:
+          ephemeral-storage: 64Mi
+        limits:
+          ephemeral-storage: 128Mi
+YAML
+
+deadline=$((SECONDS + 300))
+while ((SECONDS < deadline)); do
+  phase="$(kubectl get pod writable-layer-probe -n "${namespace}" -o jsonpath='{.status.phase}')"
+  reason="$(kubectl get pod writable-layer-probe -n "${namespace}" -o jsonpath='{.status.reason}')"
+  message="$(kubectl get pod writable-layer-probe -n "${namespace}" -o jsonpath='{.status.message}')"
+  waiting_reason="$(kubectl get pod writable-layer-probe -n "${namespace}" \
+    -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}')"
+
+  if [[ "${reason}" == "Evicted" && "${message}" == *ephemeral-storage* ]]; then
+    printf "Kata writable-layer accounting appears enforced in context %s.\n" "${context}"
+    printf "It is safe to test guardian ephemeral-storage request=1Gi and limit=8Gi in canary values.\n"
+    exit 0
+  fi
+  if [[ "${phase}" == "Running" ]] &&
+    kubectl exec -n "${namespace}" writable-layer-probe -- test -f /rootfs-probe; then
+    sleep 15
+  elif [[ "${waiting_reason}" == "ErrImagePull" || "${waiting_reason}" == "ImagePullBackOff" ]]; then
+    printf "Kata storage test image could not be pulled\n" >&2
+    exit 1
+  else
+    sleep 5
+  fi
+done
+
+printf "Kata writable-layer accounting was not demonstrated within five minutes.\n" >&2
+printf "Leave components.guardian.ephemeralStorage.enabled=false and rely on in-guest metrics/remediation.\n" >&2
+exit 2

--- a/.scripts/kubernetes/update-infra-fast-forward.sh
+++ b/.scripts/kubernetes/update-infra-fast-forward.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_dir="${INFRA_EXTERNAL_DIR:-/root/infra-external}"
+
+fail() {
+  printf "ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+[[ -d "${repo_dir}/.git" ]] || fail "${repo_dir} is not an infra-external clone"
+
+machine_drift="$(git -C "${repo_dir}" status --porcelain --untracked-files=all)"
+[[ -z "${machine_drift}" ]] ||
+  fail "machine-local drift exists; refusing to update or overwrite it"
+
+upstream="$(git -C "${repo_dir}" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)"
+[[ -n "${upstream}" ]] || fail "the current branch has no configured upstream"
+
+git -C "${repo_dir}" fetch
+local_head="$(git -C "${repo_dir}" rev-parse HEAD)"
+upstream_head="$(git -C "${repo_dir}" rev-parse "${upstream}")"
+
+if [[ "${local_head}" == "${upstream_head}" ]]; then
+  printf "infra-external is already at %s\n" "${upstream_head}"
+  exit 0
+fi
+
+git -C "${repo_dir}" merge-base --is-ancestor "${local_head}" "${upstream_head}" ||
+  fail "local history diverged from ${upstream}; refusing a reset or non-fast-forward update"
+
+git -C "${repo_dir}" merge --ff-only "${upstream}"
+updated_head="$(git -C "${repo_dir}" rev-parse HEAD)"
+[[ "${updated_head}" == "${upstream_head}" ]] ||
+  fail "fast-forward verification failed"
+printf "infra-external fast-forwarded to %s\n" "${updated_head}"


### PR DESCRIPTION
## Summary

- deploy the single-replica guardian with `Recreate`, heartbeat readiness, and immutable digest support
- configure explicit network-specific heartbeat RPC fallbacks
- add a least-privilege, non-Kata guardian remediator CronJob with rollout and cooldown guards
- make installation preflight-first and transactional with atomic Helm upgrades
- add same-network fleet-health and one-host rollout safety gates
- add isolated Kata storage, remediator, RBAC, Helm, and fleet-health validation scripts

## Why

A guardian could remain unhealthy inside a reused Kata sandbox after repeated container failures. The existing rollout path also used mutable image behavior and did not enforce same-network quorum, transactional Helm upgrades, or a single-signer `Recreate` strategy.

This change makes heartbeat health visible to Kubernetes, pins production images by digest, limits remediation to one unhealthy guardian Deployment, and stops a rollout when fleet or host safety checks fail.

## Stack

1. Credential and Secret-reference prerequisite: [switchboard-xyz/infra-external#70](https://github.com/switchboard-xyz/infra-external/pull/70)
2. **This PR:** guardian resilience and Kata remediation

Application release prerequisite: [switchboard-xyz/sbv3#1061](https://github.com/switchboard-xyz/sbv3/pull/1061).

This draft targets upstream `main` because the head branches are in a fork. It temporarily includes the prerequisite commit. Do not merge it before PR 1. After PR 1 merges, restack this branch onto the updated upstream `main` with `--force-with-lease` and verify the reduced diff.

## Verification

- Helm lint and guardian resilience render tests passed
- credential Secret-reference test passed
- offline fleet-health test passed
- shell syntax checks passed
- `git diff --check` passed

GitHub's GitLeaks action currently fails before scanning this fork PR because the organization's `GITLEAKS_LICENSE` Secret is not exposed to fork workflows. An upstream maintainer branch or authorized maintainer rerun is required; the workflow should not be weakened to expose repository Secrets to fork code.

The live k3s/Kata test namespace, RBAC assertions, missing-account fault injection, credential rotation, native-amd64 image publication, and fleet rollout have not been run.

## Deployment boundary

This PR is not independently deployable. Rollout requires:

- the credential prerequisite deployed and the exposed value revoked
- a native-amd64 guardian image built from the approved `sbv3` commit and recorded by immutable digest
- a read-only fleet baseline with at least five healthy guardians on the same network before each replacement
- one devnet canary, then one-host-at-a-time rollout with the documented soak and stop conditions
- separate explicit authorization before any mainnet Secret or workload mutation

No Kubernetes, registry, host, wallet, or on-chain state is changed by this PR.
