### PR TITLE
Inject private Sui RPC into oracle task runner

### DIFF
--- a/.scripts/helm/cfg/devnet-solana-values.yaml
+++ b/.scripts/helm/cfg/devnet-solana-values.yaml
@@ -7,6 +7,10 @@ host: "__CLUSTER_DOMAIN__"
 
 payerSecretKey: "__PAYER_SECRET_KEY__"
 
+taskRunnerRpc:
+  secretName: "__TASK_RUNNER_RPC_SECRET_NAME__"
+  suiMainnetRpcKey: "__TASK_RUNNER_SUI_RPC_SECRET_KEY__"
+
 components:
     oracle:
       image: "__ORACLE_DOCKER_IMAGE__"

--- a/.scripts/helm/cfg/mainnet-solana-values.yaml
+++ b/.scripts/helm/cfg/mainnet-solana-values.yaml
@@ -7,6 +7,10 @@ host: "__CLUSTER_DOMAIN__"
 
 payerSecretKey: "__PAYER_SECRET_KEY__"
 
+taskRunnerRpc:
+  secretName: "__TASK_RUNNER_RPC_SECRET_NAME__"
+  suiMainnetRpcKey: "__TASK_RUNNER_SUI_RPC_SECRET_KEY__"
+
 components:
     oracle:
       image: "__ORACLE_DOCKER_IMAGE__"

--- a/.scripts/helm/charts/on-demand/Chart.yaml
+++ b/.scripts/helm/charts/on-demand/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.scripts/helm/charts/on-demand/templates/oracle.yaml
+++ b/.scripts/helm/charts/on-demand/templates/oracle.yaml
@@ -45,7 +45,14 @@ spec:
       dnsPolicy: ClusterFirst # TODO: probably not needed.. to be removed
 
       containers:
+      {{- if $.Values.components.oracle.imageDigest }}
+      {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" $.Values.components.oracle.imageDigest) }}
+      {{- fail "components.oracle.imageDigest must be a sha256 digest" }}
+      {{- end }}
+      - image: {{ printf "%s@%s" $.Values.components.oracle.image $.Values.components.oracle.imageDigest | quote }}
+      {{- else }}
       - image: {{ printf "%s:%s" $.Values.components.oracle.image $.Values.components.docker_image_tag | quote }}
+      {{- end }}
         imagePullPolicy: Always #IfNotPresent
         name: oracle
 
@@ -99,6 +106,13 @@ spec:
           value: {{ $.Values.wssRpcUrl | quote }}
         - name: TASK_RUNNER_SOLANA_RPC
           value: {{ $.Values.solanaMainnetRpc | quote }}
+        {{- if $.Values.taskRunnerRpc.secretName }}
+        - name: SUI_MAINNET_RPC
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.taskRunnerRpc.secretName | quote }}
+              key: {{ required "taskRunnerRpc.suiMainnetRpcKey is required when taskRunnerRpc.secretName is set" $.Values.taskRunnerRpc.suiMainnetRpcKey | quote }}
+        {{- end }}
         - name: KEYPAIR_PATH
           value: "/data/protected_files/keypair.bin"
         - name: PAYER_SECRET

--- a/.scripts/helm/charts/on-demand/tests/task-runner-rpc-render.sh
+++ b/.scripts/helm/charts/on-demand/tests/task-runner-rpc-render.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+chart_dir="$(readlink -f "${script_dir}/..")"
+digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+oracle_digest_render="$(
+  helm template task-runner-rpc "${chart_dir}" \
+    --show-only templates/oracle.yaml \
+    --set-string taskRunnerRpc.secretName=task-runner-rpc \
+    --set-string taskRunnerRpc.suiMainnetRpcKey=SUI_MAINNET_RPC \
+    --set-string taskRunnerRpc.secretValue=SHOULD_NOT_RENDER \
+    --set-string components.oracle.imageDigest="${digest}"
+)"
+
+grep -q 'image: "docker.io/switchboardlabs/oracle@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' \
+  <<<"${oracle_digest_render}"
+grep -q 'name: SUI_MAINNET_RPC' <<<"${oracle_digest_render}"
+grep -q 'secretKeyRef:' <<<"${oracle_digest_render}"
+grep -q 'name: "task-runner-rpc"' <<<"${oracle_digest_render}"
+grep -q 'key: "SUI_MAINNET_RPC"' <<<"${oracle_digest_render}"
+[[ "$(grep -c 'name: SUI_MAINNET_RPC' <<<"${oracle_digest_render}")" -eq 1 ]]
+! grep -q 'SHOULD_NOT_RENDER' <<<"${oracle_digest_render}"
+
+oracle_default_render="$(
+  helm template task-runner-rpc "${chart_dir}" \
+    --show-only templates/oracle.yaml
+)"
+! grep -q 'SUI_MAINNET_RPC' <<<"${oracle_default_render}"
+
+guardian_render="$(
+  helm template task-runner-rpc "${chart_dir}" \
+    --show-only templates/guardian.yaml \
+    --set-string taskRunnerRpc.secretName=task-runner-rpc
+)"
+gateway_render="$(
+  helm template task-runner-rpc "${chart_dir}" \
+    --show-only templates/gateway.yaml \
+    --set-string taskRunnerRpc.secretName=task-runner-rpc
+)"
+! grep -q 'SUI_MAINNET_RPC' <<<"${guardian_render}"
+! grep -q 'SUI_MAINNET_RPC' <<<"${gateway_render}"
+
+oracle_tag_render="$(
+  helm template task-runner-rpc "${chart_dir}" \
+    --show-only templates/oracle.yaml \
+    --set-string components.docker_image_tag=stable
+)"
+grep -q 'image: "docker.io/switchboardlabs/oracle:stable"' <<<"${oracle_tag_render}"
+
+if helm template task-runner-rpc "${chart_dir}" \
+  --show-only templates/oracle.yaml \
+  --set-string taskRunnerRpc.secretName=task-runner-rpc \
+  --set-string taskRunnerRpc.suiMainnetRpcKey= >/dev/null 2>&1; then
+  printf "expected a configured Secret without a key to fail rendering\n" >&2
+  exit 1
+fi
+
+if helm template task-runner-rpc "${chart_dir}" \
+  --show-only templates/oracle.yaml \
+  --set-string components.oracle.imageDigest=latest >/dev/null 2>&1; then
+  printf "expected an invalid oracle digest to fail rendering\n" >&2
+  exit 1
+fi
+
+printf "task-runner RPC Helm render checks passed\n"

--- a/.scripts/helm/charts/on-demand/values.yaml
+++ b/.scripts/helm/charts/on-demand/values.yaml
@@ -18,6 +18,10 @@ solanaMainnetRpc: ""
 
 jupiterSwapApiKey: ""
 
+taskRunnerRpc:
+  secretName: ""
+  suiMainnetRpcKey: "SUI_MAINNET_RPC"
+
 debug: ""
 verbose: ""
 list_config_and_exit: ""
@@ -31,6 +35,7 @@ components:
   oracle:
     enabled: true
     image: "docker.io/switchboardlabs/oracle"
+    imageDigest: ""
     queue: ""
     key: ""
     port: 8081
@@ -100,4 +105,3 @@ components:
       requests:
         cpu: "100m"
         memory: "100Mi"
-

--- a/.scripts/kubernetes/k8s-oracle-install.sh
+++ b/.scripts/kubernetes/k8s-oracle-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -u -e
+set -euo pipefail
 
 cluster="${1:-devnet}"
 
@@ -64,8 +64,62 @@ load_vars "${tmp_helm_file}" >/dev/null 2>&1
 load_vars "${landing_tmp_helm_file}" >/dev/null 2>&1
 
 sgx_data_dir="${repo_dir}/data/${cluster}_protected_files"
-if [ ! -d "${repo_dir}" ]; then
-  mkdir "${repo_dir}"
+task_runner_sui_rpc_file="${sgx_data_dir}/${TASK_RUNNER_SUI_RPC_PROTECTED_FILE}"
+
+if [[ "${ORACLE_ENABLED}" == "true" && -n "${TASK_RUNNER_RPC_SECRET_NAME}" ]]; then
+  if [[ -z "${TASK_RUNNER_SUI_RPC_SECRET_KEY}" ||
+    -z "${TASK_RUNNER_SUI_RPC_PROTECTED_FILE}" ]]; then
+    printf "ERROR: task-runner RPC Secret key and protected filename are required\n" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "${task_runner_sui_rpc_file}" ]]; then
+    printf "ERROR: missing protected Sui RPC file for %s\n" "${cluster}" >&2
+    exit 1
+  fi
+
+  if [[ ! -s "${task_runner_sui_rpc_file}" ]]; then
+    printf "ERROR: protected Sui RPC file for %s is empty\n" "${cluster}" >&2
+    exit 1
+  fi
+
+  if [[ "$(stat -c '%a' "${task_runner_sui_rpc_file}")" != "600" ]]; then
+    printf "ERROR: protected Sui RPC file for %s must have mode 0600\n" "${cluster}" >&2
+    exit 1
+  fi
+
+  if [[ "$(wc -l < "${task_runner_sui_rpc_file}")" -ne 0 ]] ||
+    LC_ALL=C grep -q $'\r' "${task_runner_sui_rpc_file}"; then
+    printf "ERROR: protected Sui RPC file for %s must not contain a newline\n" "${cluster}" >&2
+    exit 1
+  fi
+
+  if [[ "$(head -c 8 "${task_runner_sui_rpc_file}")" != http://* &&
+    "$(head -c 9 "${task_runner_sui_rpc_file}")" != https://* ]]; then
+    printf "ERROR: protected Sui RPC file for %s must contain an HTTP(S) URL\n" "${cluster}" >&2
+    exit 1
+  fi
+
+  printf "KUBECTL: reconciling %s/%s\n" "${NAMESPACE}" "${TASK_RUNNER_RPC_SECRET_NAME}"
+  kubectl \
+    -n "${NAMESPACE}" \
+    create secret generic "${TASK_RUNNER_RPC_SECRET_NAME}" \
+    --from-file="${TASK_RUNNER_SUI_RPC_SECRET_KEY}=${task_runner_sui_rpc_file}" \
+    --dry-run=client \
+    -o yaml |
+    kubectl apply -f - >/dev/null
+
+  if [[ "$(
+    kubectl \
+      -n "${NAMESPACE}" \
+      get secret "${TASK_RUNNER_RPC_SECRET_NAME}" \
+      --template="{{if index .data \"${TASK_RUNNER_SUI_RPC_SECRET_KEY}\"}}present{{end}}"
+  )" != "present" ]]; then
+    printf "ERROR: %s/%s is missing the required key\n" \
+      "${NAMESPACE}" "${TASK_RUNNER_RPC_SECRET_NAME}" >&2
+    exit 1
+  fi
+  printf "KUBECTL: %s/%s reconciled\n" "${NAMESPACE}" "${TASK_RUNNER_RPC_SECRET_NAME}"
 fi
 
 printf "HELM: Installing Switchboard Oracle under namespace ${NAMESPACE}\n"
@@ -76,6 +130,7 @@ helm upgrade -i "sb-oracle-${NETWORK}" \
   --set components.docker_image_tag="${DOCKER_IMAGE_TAG}" \
   --set components.oracle.enabled=${ORACLE_ENABLED} \
   --set components.oracle.image="${ORACLE_DOCKER_IMAGE}" \
+  --set-string components.oracle.imageDigest="${ORACLE_DOCKER_IMAGE_DIGEST}" \
   --set components.guardian.enabled=${GUARDIAN_ENABLED} \
   --set components.guardian.image="${GUARDIAN_DOCKER_IMAGE}" \
   --set components.gateway.enabled=${GATEWAY_ENABLED} \

--- a/.scripts/var/_load_vars.sh
+++ b/.scripts/var/_load_vars.sh
@@ -14,6 +14,8 @@ function load_vars() {
   sed -E -i 's;(__|\$\{)RPC_URL(\}|__);'"${RPC_URL}"';g' "${tmp_helm_file}"
   sed -E -i 's;(__|\$\{)WSS_RPC_URL(\}|__);'"${WSS_RPC_URL}"';g' "${tmp_helm_file}"
   sed -E -i 's;(__|\$\{)TASK_RUNNER_SOLANA_RPC(\}|__);'"${TASK_RUNNER_SOLANA_RPC}"';g' "${tmp_helm_file}"
+  sed -E -i 's;(__|\$\{)TASK_RUNNER_RPC_SECRET_NAME(\}|__);'"${TASK_RUNNER_RPC_SECRET_NAME}"';g' "${tmp_helm_file}"
+  sed -E -i 's;(__|\$\{)TASK_RUNNER_SUI_RPC_SECRET_KEY(\}|__);'"${TASK_RUNNER_SUI_RPC_SECRET_KEY}"';g' "${tmp_helm_file}"
   sed -E -i 's;(__|\$\{)PULL_QUEUE(\}|__);'"${PULL_QUEUE}"';g' "${tmp_helm_file}"
   sed -E -i 's;(__|\$\{)PULL_ORACLE(\}|__);'"${PULL_ORACLE}"';g' "${tmp_helm_file}"
   sed -E -i 's;(__|\$\{)ORACLE_ENABLED(\}|__);'"${ORACLE_ENABLED}"';g' "${tmp_helm_file}"

--- a/cfg/00-common-vars.cfg
+++ b/cfg/00-common-vars.cfg
@@ -13,6 +13,12 @@ CLUSTER_DOMAIN="${IPv4}.xip.switchboard-oracles.xyz"
 # this URL should always be a MAINNET non rate-limited RPC (even when using devnet)
 TASK_RUNNER_SOLANA_RPC="https://api.mainnet-beta.solana.com"
 
+# Oracle task-runner Sui JSON-RPC configuration. Store the endpoint at
+# data/<network>_protected_files/sui-mainnet-rpc with mode 0600 and no newline.
+TASK_RUNNER_RPC_SECRET_NAME="task-runner-rpc"
+TASK_RUNNER_SUI_RPC_SECRET_KEY="SUI_MAINNET_RPC"
+TASK_RUNNER_SUI_RPC_PROTECTED_FILE="sui-mainnet-rpc"
+
 LANDING_ENABLED="true"
 
 ##########
@@ -23,6 +29,7 @@ DEVNET_DOCKER_IMAGE_TAG="devnet"
 MAINNET_DOCKER_IMAGE_TAG="stable"
 
 ORACLE_DOCKER_IMAGE="docker.io/switchboardlabs/oracle"
+ORACLE_DOCKER_IMAGE_DIGEST=""
 GATEWAY_DOCKER_IMAGE="docker.io/switchboardlabs/gateway"
 GUARDIAN_DOCKER_IMAGE="docker.io/switchboardlabs/guardian"
 


### PR DESCRIPTION
## Summary

- add optional oracle-only SUI_MAINNET_RPC injection through a required Kubernetes secretKeyRef
- reconcile task-runner-rpc from an untracked mode-0600 protected file before Helm changes
- add optional immutable oracle image digest rendering while preserving tag-based deployments
- add Helm render coverage for Secret isolation, secret-value exclusion, digest validation, and tag fallback

## Root cause and impact

The vSUI task runner needs a private Sui JSON-RPC endpoint after the public fullnode JSON-RPC deprecation. This change keeps endpoint material out of values, command-line overrides, images, and rendered manifests. Only the oracle Deployment receives the Secret reference; guardian and gateway remain unchanged.

## Release unit

Companion application PR: https://github.com/switchboard-xyz/sbv3/pull/1073

Merge the application PR first. After its oracle image is published, place that immutable digest in this infrastructure change, provision the RPC Secret, and only then begin a rollout. Neither half should be rolled out independently without the operator RPC Secret in place.

No image was built or published, no digest was pinned, no Secret was provisioned, and no cluster was changed as part of this PR.

## Validation

- task-runner-rpc-render.sh passes
- helm lint passes for .scripts/helm/charts/on-demand
- devnet and mainnet values render successfully with exactly one SUI_MAINNET_RPC reference
- bash -n passes for the installer, render test, and variable loader
- GitLeaks CI currently fails before scanning because the organization workflow requires a GITLEAKS_LICENSE value; it reported no secret finding from this diff

## Follow-up

AftermathTask and the legacy SUI_RPC_URL behavior are intentionally outside this hotfix and should be standardized separately.