### PR TITLE
fix(infra): harden Alloy diagnostics and RBAC

### DIFF
--- a/.scripts/helm/charts/oracle-log-forwarding/values.yaml
+++ b/.scripts/helm/charts/oracle-log-forwarding/values.yaml
@@ -4,7 +4,82 @@ alloy:
     password: "set-me"
   operator: switchboard
   oracleIPv4: "someIP"
+  # The upstream role includes ConfigMap and Secret access for components this
+  # deployment does not use. Recreate the chart's RBAC without that rule.
+  rbac:
+    create: false
+  extraObjects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: '{{ include "alloy.fullname" . }}'
+      labels:
+        helm.sh/chart: '{{ include "alloy.chart" . }}'
+        app.kubernetes.io/name: '{{ include "alloy.name" . }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/version: '{{ (include "alloy.imageId" .) | trunc 15 | trimPrefix "@sha256" | trimPrefix ":" }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/part-of: alloy
+        app.kubernetes.io/component: rbac
+    rules:
+    - apiGroups: ["", "discovery.k8s.io", "networking.k8s.io"]
+      resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods", "pods/log", "namespaces"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["monitoring.grafana.com"]
+      resources: ["podlogs"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["prometheusrules"]
+      verbs: ["get", "list", "watch"]
+    - nonResourceURLs: ["/metrics"]
+      verbs: ["get"]
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["podmonitors", "servicemonitors", "probes"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["apps"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["extensions"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: '{{ include "alloy.fullname" . }}'
+      labels:
+        helm.sh/chart: '{{ include "alloy.chart" . }}'
+        app.kubernetes.io/name: '{{ include "alloy.name" . }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/version: '{{ (include "alloy.imageId" .) | trunc 15 | trimPrefix "@sha256" | trimPrefix ":" }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/part-of: alloy
+        app.kubernetes.io/component: rbac
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: '{{ include "alloy.fullname" . }}'
+    subjects:
+    - kind: ServiceAccount
+      name: '{{ include "alloy.serviceAccountName" . }}'
+      namespace: '{{ include "alloy.namespace" . }}'
   alloy:
+    extraArgs:
+    - --server.http.disable-support-bundle=true
+    - --server.http.enable-pprof=false
     extraPorts:
     - name: otlp-grpc # The default port for otlp-grpc is 4317, so you need to add this port to the service related to your alloy instance
       port: 4317


### PR DESCRIPTION
## Summary

- disable Alloy v1.7.4 support-bundle generation and pprof endpoints;
- replace the dependency chart's generic ClusterRole with the same rules minus `get`, `list`, and `watch` access to ConfigMaps and Secrets; and
- preserve the existing resource names, Helm labels, binding, readiness/reload behavior, service ports, log sources, and OTLP inputs.

## Why

This deployment uses `discovery.kubernetes`, `loki.source.kubernetes`, and `loki.source.kubernetes_events`, but it does not use `remote.kubernetes`, which is the component the upstream chart documents as requiring ConfigMap and Secret access. The generic chart role therefore grants this workload more Kubernetes API access than its current configuration needs.

Alloy's internal HTTP server also exposes optional diagnostics that are unnecessary for this deployment. Disabling support-bundle generation and pprof reduces the in-cluster diagnostic surface while retaining readiness and config reload endpoints.

This is a Low/P3 defense-in-depth change. No public Alloy Service exposure was identified, and this PR does not claim that Alloy's redacted support bundle exposes the Loki password.

## Compatibility

The locked before/after render proves:

- the rendered resource set is unchanged;
- the Alloy DaemonSet differs only by the two diagnostic flags;
- the ClusterRole differs only by removal of the ConfigMap/Secret rule;
- the ClusterRole and ClusterRoleBinding names, labels, role reference, and subject are preserved; and
- ports `12345`, `4317`, and `4318`, the `/-/ready` probe, the config-reloader sidecar, and the Alloy v1.7.4 image are unchanged.

No live cluster rollout or credential rotation is part of this PR.

## Validation

- `helm dependency build --skip-refresh` using committed `Chart.lock` (Alloy chart `0.12.5`)
- `helm lint` on both the `origin/main` baseline and patched chart
- `helm template` on both charts in namespace `sb-log-forwarding`
- dependency-free semantic comparison of the rendered resources
- source check confirming no `remote.kubernetes` component is configured
- `git diff --check`
